### PR TITLE
Reviewed Formatting

### DIFF
--- a/Formatting_Cheat-Sheet.md
+++ b/Formatting_Cheat-Sheet.md
@@ -5,6 +5,18 @@ orphan: true
 Formatting Cheat Sheet
 ====
 
+## General Formatting Guidelines
+
+Add an empty line...
+- ...after a heading
+- ...before and after an admonition or codeblock
+- ...after the admonition class for custom admonitions
+- ...after a tab opening and before a tab closing as shown in the [Tabs Section](#tabs)
+- ...before and after tables
+- ...before and after image inserts with custom properties
+
+Don't add an empty line around admonitions within lists
+
 ## Footnotes
 
 - This is a manually-numbered footnote reference.[^3]
@@ -28,19 +40,18 @@ that are not separated by a blank line
 
 ## Tabs
 
-````{tabs}
-
-```{group-tab} macOS
-
-test
-```
-
-```{group-tab} Windows
+::::{tabs}
+:::{group-tab} macOS
 
 test
-```
 
-````
+:::
+:::{group-tab} Windows
+
+test
+
+:::
+::::
 
 ---
 

--- a/Formatting_Cheat-Sheet.md
+++ b/Formatting_Cheat-Sheet.md
@@ -17,6 +17,8 @@ Add an empty line...
 
 Don't add an empty line around admonitions within lists
 
+Indent codeblocks within numbered lists, as the numbers aren't rendered correctly otherwise.
+
 ## Footnotes
 
 - This is a manually-numbered footnote reference.[^3]
@@ -75,47 +77,47 @@ test
 
 ## Admonitions
 
-```{note}
+:::{note}
 Here is a note!
-```
+:::
 
-```{warning}
+:::{warning}
 Here is a warning!
-```
+:::
 
-```{tip}
+:::{tip}
 Here is a tip!
-```
+:::
 
-```{caution}
+:::{caution}
 Caution!
-```
+:::
 
-```{attention}
+:::{attention}
 Attention!
-```
+:::
 
-```{danger}
+:::{danger}
 Here is a danger!
-```
+:::
 
-```{error}
+:::{error}
 Here is an error!
-```
+:::
 
-```{hint}
+:::{hint}
 Here is a hint!
-```
+:::
 
-```{important}
+:::{important}
 This is important!
-```
+:::
 
-```{seealso}
+:::{seealso}
 See also here!
-```
+:::
 
-```{admonition} Custom
+:::{admonition} Custom
 :class: tip
 Custom content
-```
+:::

--- a/cli/index.md
+++ b/cli/index.md
@@ -1,43 +1,47 @@
 Command Line Interface (CLI)
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 support
-```
+:::
 
 [Cyberduck with a command-line interface (CLI)](https://duck.sh/) is available for Mac, Windows & Linux. It is installed as `duck`.
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Installation
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 **Homebrew**
 
 Available as a [Homebrew](http://brew.sh/) package. Use
-```{code-block}
+
+```
 brew install duck
 ```
-to install.
 
+to install.
 
 **MacPorts**
 
 The port is maintained by a third party. Use
-```{code-block}
+
+```
 sudo port install duck
 ```
+
 to install.
 
 **Snapshot Builds**
-```{code-block}
+
+```
 brew install iterate-ch/cyberduck/duck
 ```
 
@@ -45,35 +49,34 @@ brew install iterate-ch/cyberduck/duck
 
 [Download](https://dist.duck.sh) the latest installer package.
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 **Chocolatey**
 
 Available as a [Chocolatey](https://chocolatey.org) package. Use
-```{code-block}
+
+```
 choco install duck
 ```
+
 to install.
-
-
 
 **MSI Installer**
 
 [Download](https://dist.duck.sh) the latest setup.
 
-
 **Snapshot Builds**
 
 Not currently available.
 
-```{image} _images/CLI_Setup.png
+:::{image} _images/CLI_Setup.png
 :alt: CLI Setup
 :width: 500px
-```
+:::
 
-````
-````{group-tab} Linux
+::::
+:::::{group-tab} Linux
 
 **RPM Package Repository**
 
@@ -83,7 +86,7 @@ To add the `duck` repository to your system you need to put a file `duck.repo` w
 
 Copy and paste
 
-```{code-block}
+```
 echo -e "[duck-nightly]\n\
 name=duck-nightly\n\
 baseurl=https://repo.cyberduck.io/nightly/\$basearch/\n\
@@ -95,7 +98,7 @@ to add the configuration.
 
 **Stable Builds**
 
-```{code-block}
+```
 echo -e "[duck-stable]\n\
 name=duck-stable\n\
 baseurl=https://repo.cyberduck.io/stable/\$basearch/\n\
@@ -109,44 +112,41 @@ To install *Cyberduck CLI* use
 **DEB Package Repository**
 
 1. Add the nightly or stable `duck` repository to your `/etc/apt/sources.list` manually:
-```{code-block}
+```
 deb https://s3.amazonaws.com/repo.deb.cyberduck.io nightly main
 deb https://s3.amazonaws.com/repo.deb.cyberduck.io stable main
 ```
 or using 
-```{code-block}
+```
 echo -e "deb https://s3.amazonaws.com/repo.deb.cyberduck.io stable main" | sudo tee /etc/apt/sources.list.d/cyberduck.list > /dev/null
 ```
 2. You need to download the GPG public key from `keyserver.ubuntu.com` to verify the integrity of the packages:
-```{code-block}
+```
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FE7097963FEFBE72
 ```
-
 3. Synchronize the repository using 
-```{code-block}
+```
 sudo apt-get update
 ```
-
 4. To install or upgrade *Cyberduck CLI* use
-```{code-block}
+```
 sudo apt-get install duck
 ```
 
-```{warning}
+:::{warning}
 You may get a conflict with another package named `duck`. As a workaround, install with a specific version number like `sudo apt-get install duck=6.7.1.28683`.
-```
+:::
 
 **Arch Linux Package**
 
 - [Package Details](https://aur.archlinux.org/packages/duck/). *Note*: This is maintained by a third party.
 
-
 **Manual Installation**
 
 Packages can also be found for [download](https://dist.duck.sh/).
 
-````
-`````
+::::
+:::::
 
 ## Usage
 
@@ -156,9 +156,9 @@ Run `--help` to get the option screen.
 
 URLs in arguments must be fully qualified. You can reference files relative to your home directory with `/~ftps://user@example.net/~/`.
 
-```{attention}
+:::{attention}
 Paths can either denote a remote file `ftps://user@example.net/resource` or folder `ftps://user@example.net/directory/` with a trailing `/`. 
-```
+:::
 
 ### Connection Profiles
 
@@ -174,15 +174,15 @@ The `<url>` argument for `--copy`, `--download`, `--upload`, and `--synchronize`
     - For all protocols where a default hostname is set, but you are allowed to change it (e.g. S3) you may use fully qualified URIs or 
     *Absolute paths:* `s3:/bucket/path`,
     *Relative paths:* `s3:user@path` or `s3:user@/path`. 
-    ```{note}
+    :::{note}
     Omitting the first slash in a relative path uses the default home directory for this protocol.
-    ```
+    :::
     - For all protocols where a default hostname is set and you are not allowed to change it (e.g. `OneDrive`, `Dropbox`, `Google Drive`) you may use any combination of the above with the following rules: Fully Qualified URIs are parsed as relative paths. `onedrive://Some/Folder/` is parsed as `onedrive:Some/Folder`.
 - For all protocols where a default path is set and you are not allowed to change it (e.g. accessing a prebuilt `NextCloud` profile with a path set to `/remote.php/webdav`). You are allowed to change the path but it will be appended to the default path. Making nextcloud:/path really `nextcloud:/remote.php/webdav/path`.
 
-```{note}
+:::{note}
 Spaces and other special-characters are not required to be percent-encoded (e.g. `%20` for space) as long as the path is quoted `duck --upload "scheme://hostname/path with/spaces" "/Path/To/Local/File With/Spaces"`.
-```
+:::
 
 | Protocol                               | Fully Qualified URI required                       | Absolute Path                                           | Relative Path                                          |
 |----------------------------------------|----------------------------------------------------|---------------------------------------------------------|--------------------------------------------------------|
@@ -208,25 +208,26 @@ Spaces and other special-characters are not required to be percent-encoded (e.g.
 
 #### Examples
 
-```{admonition} Home Directory
+:::{admonition} Home Directory
 :class: tip
+
 You can use the `~` character to abbreviate the remote path pointing to the home folder on the server as in `duck --list sftp://duck.sh/~/`.
-```
+:::
 
 - List all buckets in S3 with 
-```{code-block}
+```
 duck --username <Access Key ID> --list s3:/
 ```
 - List all objects in a S3 bucket with
-```{code-block}
+```
 duck --username <Access Key ID> --list s3:/<bucketname>/
 ```
 - List a vault on OneDrive without using the `--vault` option
-```{code-block}
+```
 duck --list "onedrive:/My Files/<vault name>/"
 ```
 - Download a single file from a vault on OneDrive
-```{code-block}
+```
 duck --download "onedrive:/My Files/<vault name>/<file name>" ~/Downloads/ --vault "/My Files/<vault name>/"
 ```
 
@@ -266,20 +267,20 @@ When connecting with `OpenStack Swift` you can set the tenant name (*OpenStack I
 
 ### Downloads with `--download`
 
-* Download file `<file>` to directory `<folder>` on disk using
-```{code-block}
+- Download file `<file>` to directory `<folder>` on disk using
+```
 duck --download protocol:/<file> <folder>/
 ```
-
-* Download file `<file>` as `<name>` to directory `<folder>` on disk using
-```{code-block}
+- Download file `<file>` as `<name>` to directory `<folder>` on disk using
+```
 duck --download protocol:/<file> <folder>/<name>
 ```
 
 #### Glob Pattern Support for Selecting Files to Transfer
 
 You can transfer multiple files with a single command using a glob pattern for filename inclusion such as
-```{code-block}
+
+```
 duck --download protocol://<hostname>/directory/*.css
 ```
 
@@ -287,32 +288,31 @@ duck --download protocol://<hostname>/directory/*.css
 
 Note the inclusion or absence of a trailing `/` delimiter character to denote a file or directory on the server.
 
-* Upload the `<folder>` on disk to remote directory `<name>/` using
-```{code-block}
+- Upload the `<folder>` on disk to remote directory `<name>/` using
+```
 duck --upload protocol:/<name>/ <folder>/
 ```
-
-* Upload file `<file>` to remote directory `<folder>` using
-```{code-block}
+- Upload file `<file>` to remote directory `<folder>` using
+```
 duck --upload protocol:/<folder>/ <file>
 ```
-
-* Upload file `<file>` as `<name>` to remote directory `<folder>` using
-```{code-block}
+- Upload file `<file>` as `<name>` to remote directory `<folder>` using
+```
 duck --upload protocol:/<folder>/<name> <file>
 ```
 
 #### Glob Pattern Support for Selecting Files to Transfer
 
 If your shell supports glob expansion you can use a wildcard pattern to select files for upload like 
-```{code-block}
+
+```
 duck --upload protocol://<hostname>/directory/ ~/*.jpg
 ```
 
 ### Synchronize Folders with `--synchronize`
 
-* Synchronize directory `<name>` with directory `folder` on disk using
-```{code-block}
+- Synchronize directory `<name>` with directory `folder` on disk using
+```
 duck --synchronize protocol:/<name>/ folder/
 ```
 
@@ -320,12 +320,15 @@ duck --synchronize protocol:/<name>/ folder/
 
 Add default metadata for uploads using the [preferences option to read from the environment](#preferences). The property is documented in [Default metadata](../protocols/s3/index.md#default-metadata).
 
-	env "s3.metadata.default=Content-Type=application/xml" duck --upload …
+```
+env "s3.metadata.default=Content-Type=application/xml" duck --upload …
+```
 
 Set a default ACL for the upload with
 
-	env "s3.acl.default=public-read" duck --upload …
-
+```
+env "s3.acl.default=public-read" duck --upload …
+```
 
 ### Remote Directory Listing with `--list`
 
@@ -338,7 +341,8 @@ You can edit remote files with your preferred editor on your local system using 
 ### Purge Files in CDN with `--purge`
 
 Purge files in CloudFront or Akamai CDN for Amazon S3 or Rackspace CloudFiles connections. For example to invalidate all contents in a bucket run
-```{code-block}
+
+```
 duck --username AKIAIWQ7UM47TA3ONE7Q --purge s3:/github-cyberduck-docs/
 ```
 
@@ -358,7 +362,7 @@ Use `--vault <path>` in conjunction with `--upload` to unlock a Vault. This allo
 
 `fswatch` is a file change monitor; an application to watch for file system changes. Refer to their [documentation](https://github.com/emcrisostomo/fswatch/wiki).
 
-```{code-block}
+```
 fswatch -0 ~/Sites/mywebsite/ | xargs -0 -I {} -t sh -c 'f="{}"; duck --upload ftps://<hostname>/sandbox`basename "${f}"` "${f}" -existing overwrite'
 ```
 
@@ -366,22 +370,25 @@ fswatch -0 ~/Sites/mywebsite/ | xargs -0 -I {} -t sh -c 'f="{}"; duck --upload f
 
 use a post [build script action](https://plugins.jenkins.io/postbuildscript/).
 
-```{code-block}
+```
 cd ${WORKSPACE}; find build -name '*.tar' -print0 | xargs -0 -I {} -t sh -c 'f="{}"; duck --quiet --retry --existing skip --region DFW --upload rackspace://<container>/ "${f}"'
 ```
 
 ### Upload Files Matching Glob Pattern to Windows Azure
-```{code-block}
+
+```
 duck --username kahy9boj3eix --upload azure://kahy9boj3eix.blob.core.windows.net/<containername>/ *.zip
 ```
 
 ### Download Files Matching Glob Pattern from S3
-```{code-block}
+
+```
 duck --user anonymous --verbose --download s3:/profiles.cyberduck.io/Wasabi* ~/Downloads/
 ```
 
 ### Download File from Amazon S3 Public Bucket
-```{code-block}
+
+```
 duck --user anonymous --download s3:/repo.maven.cyberduck.io/releases/ch/cyberduck/s3/6.1.0/s3-6.1.0.jar ~/Downloads/
 ```
 
@@ -391,49 +398,49 @@ duck --user anonymous --download s3:/repo.maven.cyberduck.io/releases/ch/cyberdu
 
 The directory location is printed with `--help` following the list of supported protocols.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 The support directory is `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/` on Mac. You can install third party [profiles](../protocols/profiles/index.md) in `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/Profiles`.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Install additional profiles in `%AppData%\Cyberduck\Profiles` on Windows.
 
-````
-````{group-tab} Linux
+:::
+:::{group-tab} Linux
 
 The support directory is `~/.duck/` on Linux. You can install third party [profiles](../protocols/profiles/index.md) in `~/.duck/profiles/`.
 
-````
-`````
+:::
+::::
 
 ## Preferences
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 You can override default [preferences](../cyberduck/preferences.md#hidden-configuration-options) by setting environment variables in your shell.
 
 `env "property.name=value" duck`
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 You can override default [preferences](../cyberduck/preferences.md#hidden-configuration-options) by setting environment variables in your shell.
 
 `set "property.name=value" & duck`
 
-````
-````{group-tab} Linux
+:::
+:::{group-tab} Linux
 
 You can override default [preferences](../cyberduck/preferences.md#hidden-configuration-options) by setting environment variables in your shell.
 
 `env "property.name=value" duck`
 
-````
-`````
+:::
+::::
 
 ## Known Issues
 

--- a/cli/index.md
+++ b/cli/index.md
@@ -112,26 +112,26 @@ To install *Cyberduck CLI* use
 **DEB Package Repository**
 
 1. Add the nightly or stable `duck` repository to your `/etc/apt/sources.list` manually:
-```
-deb https://s3.amazonaws.com/repo.deb.cyberduck.io nightly main
-deb https://s3.amazonaws.com/repo.deb.cyberduck.io stable main
-```
+    ```
+    deb https://s3.amazonaws.com/repo.deb.cyberduck.io nightly main
+    deb https://s3.amazonaws.com/repo.deb.cyberduck.io stable main
+    ```
 or using 
-```
-echo -e "deb https://s3.amazonaws.com/repo.deb.cyberduck.io stable main" | sudo tee /etc/apt/sources.list.d/cyberduck.list > /dev/null
-```
+    ```
+    echo -e "deb https://s3.amazonaws.com/repo.deb.cyberduck.io stable main" | sudo tee /etc/apt/sources.list.d/cyberduck.list > /dev/null
+    ```
 2. You need to download the GPG public key from `keyserver.ubuntu.com` to verify the integrity of the packages:
-```
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FE7097963FEFBE72
-```
+    ```
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FE7097963FEFBE72
+    ```
 3. Synchronize the repository using 
-```
-sudo apt-get update
-```
+    ```
+    sudo apt-get update
+    ```
 4. To install or upgrade *Cyberduck CLI* use
-```
-sudo apt-get install duck
-```
+    ```
+    sudo apt-get install duck
+    ```
 
 :::{warning}
 You may get a conflict with another package named `duck`. As a workaround, install with a specific version number like `sudo apt-get install duck=6.7.1.28683`.

--- a/cli/support.md
+++ b/cli/support.md
@@ -3,47 +3,47 @@ Support
 
 ## Application Support Directory
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 You can reach the application support folder by choosing `Go → Go to folder` within the *Finder* menu, copying the path below into the appearing window, and clicking on the *Open* button afterward.
 
 `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/`
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 You can reach the application support folder by navigating to `%AppData%\Cyberduck` by copying the path into the address bar of the Explorer and press *Return* afterward.
 
-````
-````{group-tab} Linux
+:::
+:::{group-tab} Linux
 
 The support directory is `~/.duck/`.
 
-````
-`````
+:::
+::::
 
 ### Profiles
 
 The directory location is printed with `--help` following the list of supported protocols.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 You can install third party [profiles](../protocols/profiles/index.md) in `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/Profiles`.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Install additional profiles in `%AppData%\Cyberduck\Profiles` on Windows.
 
-````
-````{group-tab} Linux
+:::
+:::{group-tab} Linux
 
 You can install third party [profiles](../protocols/profiles/index.md) in `~/.duck/profiles/`.
 
-````
-`````
+:::
+::::
 
 ## Logging Output
 

--- a/cryptomator/index.md
+++ b/cryptomator/index.md
@@ -1,72 +1,72 @@
 Cryptomator
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 
 architecture/index.md
-```
+:::
 
-```{image} _images/cryptomator.png
+:::{image} _images/cryptomator.png
 :alt: Cryptomator
 :width: 400px
-```
+:::
 
 Support for client-side encryption with [Cryptomator](https://cryptomator.org/) interoperable vaults to secure your data on any server or cloud storage.
 
-```{image} _images/Browse_Cryptomator_Vault.gif
+:::{image} _images/Browse_Cryptomator_Vault.gif
 :alt: Browse Cryptomator Vault
 :width: 600px
-```
+:::
 
 The client-side encryption feature in Cyberduck and Mountain Duck is based on the excellent concepts and work of [Cryptomator](https://cryptomator.org/). Cryptomator is free and open-source software. Since Cyberduck is also open-source software anyone is able to audit the source code. That means no security by obscurity, no hidden backdoors from third parties, no need to trust anyone except yourself.
 
-```{tip}
+:::{tip}
 Compared to other client-side-encryption solutions, the Cryptomator based approach yields a few crucial advantages:
 - In addition to file content encryption, file and directory names are encrypted and directory structures obfuscated.
 - No online services, no subscriptions, no accounts.
 - No need to share your cloud storage provider credentials.
-```
+:::
 
 ## Create new Vault
 
 You can create a new vault directory anywhere on your remote storage. This will initialize the vault with a `masterkey.cryptomator`. A backup of the master key file (`masterkey.cryptomator`) is saved in user defaults. The encrypted keys in `masterkey.cryptomator` are not more sensitive than the encrypted files in the vault. For technical aspects, refer to [Masterkey Derivation](https://docs.cryptomator.org/en/latest/security/architecture/#masterkey-derivation).
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *File → New Vault…* to create a new vault. 
 
-```{image} _images/New_Encrypted_Vault_File_Menu_Option.png
+:::{image} _images/New_Encrypted_Vault_File_Menu_Option.png
 :alt: New Encrypted Vault File Menu Option
 :width: 400px
-```
+:::
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 - Choose *New Vault…* from the Finder Extension toolbar or context menu using right-click in Finder or Windows Explorer.
 
-```{image} _images/Mountain_Duck_Create_New_Vault_Finder_Extension.png
+:::{image} _images/Mountain_Duck_Create_New_Vault_Finder_Extension.png
 :alt: Mountain Duck Create New Vault (Finder Extension)
 :width: 400px
-```
+:::
 
-```{image} _images/Mountain_Duck_Create_New_Vault_Windows_Explorer.png
+:::{image} _images/Mountain_Duck_Create_New_Vault_Windows_Explorer.png
 :alt: Mountain Duck Create New Vault (Windows Explorer)
 :width: 400px
-```
+:::
 
 - Choose a name for the Vault folder and a passphrase to secure the Vault.
 
-```{image} _images/Create_New_Vault.png
+:::{image} _images/Create_New_Vault.png
 :alt: Create New Vault
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ## Unlock Vault
 
@@ -74,68 +74,68 @@ Choose *File → New Vault…* to create a new vault.
 
 When _Preferences → Cryptomator → Auto detect and open vault in browser_ is enabled, opening a directory in the browser that is a Cryptomator Vault, a prompt is displayed to unlock the vault using the provided passphrase and decrypt the directory and filenames. If you cancel the prompt, the encrypted vault content is displayed.
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
-```{image} _images/Mountain_Duck_Unlock_Vault.png
+:::{image} _images/Mountain_Duck_Unlock_Vault.png
 :alt: Mountain Duck Unlock Vault
 :width: 400px
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
-```{image} _images/Mountain_Duck_Unlock_Vault_Windows.png
+:::{image} _images/Mountain_Duck_Unlock_Vault_Windows.png
 :alt: Mountain Duck Unlock Vault (Windows)
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### Manual
 
-````{tabs}
-```{group-tab} Cyberduck
+::::{tabs}
+:::{group-tab} Cyberduck
 
 Choose the *Cryptomator* button in the toolbar or *File → Unlock Vault* and *File →Lock Vault* menu to unlock or lock a vault respectively.
 
-```
-```{group-tab} Mountain Duck
+:::
+:::{group-tab} Mountain Duck
 
 Lock and unlock vaults within the Finder or Windows Explorer using the context menu:
 
 `Mountain Duck → Cryptomator → Lock Vault`
 `Mountain Duck → Cryptomator → Unlock Vault`
 
-```
-````
+:::
+::::
 
-```{attention}
+:::{attention}
 The menu option is disabled if you have set Preferences → Cryptomator → Auto detect and open vault in browser
-```
+:::
 
 ### Save Passphrase
 
 You can check *Add to Keychain* to save the passphrase to open the vault with the master key file in your login keychain. The checkbox is disabled by default. Another application that wants to access the vault passphrase from the login keychain will trigger a permission prompt.
 
-```{image} _images/Keychain_Access_Crpytomator_Passphrase.png
+:::{image} _images/Keychain_Access_Crpytomator_Passphrase.png
 :alt: Keychain Access Cryptomator Passphrase
 :width: 400px
-```
+:::
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Manage your passwords with *Keychain Access.app* on Mac. Refer to [Keychain for Mac: Keychain Access overview](https://support.apple.com/kb/PH20093?locale=en_US).
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Passwords are saved in the *Credential Manager*. You can view and delete your saved login information in *Control Panel → User Accounts → Credential Manager → Windows Credentials*.
 
-````
-`````
+:::
+::::
 
 ### File Transfers
 
@@ -151,50 +151,47 @@ When renaming a vault the behaviour depends on whether the vault is locked or un
 
 You can open and browse multiple vaults on a server in a single browser window. For each vault to be opened you will be prompted to enter your passphrase to decrypt the filenames. Decrypted filenames when browsing a vault will show a padlock overlay icon.
 
-```{image} _images/Cryptomator_Vault_Browser.png
+:::{image} _images/Cryptomator_Vault_Browser.png
 :alt: Cryptomator Vault Browser
 :width: 400px
-```
+:::
 
 ### Moving Files Into Vault
 
 You can move files from and to the vault. Because files need to be encrypted or decrypted respectively they pass through your local computer and cannot be moved on the server-side.
 
-```{attention}
+:::{attention}
 The vault must be unlocked before you move files to it, otherwise the files won't be encrypted.
-```
+:::
 
 ### Access Vaults on Local Disk
 
 Both [Cyberduck](https://cyberduck.io/) and [Mountain Duck](https://mountainduck.io/) support browsing your local disk to access vaults created on your computer. Create a new [bookmark](../cyberduck/bookmarks) to connect to your local disk.
 
-```{image} _images/local_disk_connection.png
+:::{image} _images/local_disk_connection.png
 :alt: Local Disk Connection
 :width: 400px
-```
+:::
 
 In your local disk connection, you can access all directories which are saved on your local disk. This includes for example your local synchronized [Dropbox](../protocols/dropbox), [Google Drive](../protocols/googledrive) and [OneDrive](../protocols/onedrive) directories.
 
-````{admonition} Access a Cryptomator Vault on local disk on the example of Dropbox
+::::{admonition} Access a Cryptomator Vault on local disk on the example of Dropbox
 :class: note
 
 1. Navigate to the Dropbox directory and open the subdirectories until you reach your vault.
 2. Double click your vault.
 3. Type your set password in the password box. If you want you can save the password for easier access to this directory for further usage.
-
-```{image} _images/access_Cryptomator_vault_Mountain_Duck.png
+:::{image} _images/access_Cryptomator_vault_Mountain_Duck.png
 :alt: Mountain Duck Cryptomator Vault 
 :width: 400px
-```
-
-```{image} _images/access_Cryptomator_vault_Cyberduck.png
+:::
+:::{image} _images/access_Cryptomator_vault_Cyberduck.png
 :alt: Cyberduck Access Cryptomator Vault
 :width: 400px
-```
-
+:::
 4. Click the Continue button and your vault should open.
 
-````
+::::
 
 ## Known Limitations
 
@@ -214,9 +211,9 @@ Uncheck *Preferences → Cryptomator → Auto detect and open Vault in browser* 
 
 Save the password in Keychain or Credential Manager to unlock vaults automatically upon connecting.
 
-```{note}
+:::{note}
 Without saving the vaults passwords using keychain, you will receive passwords prompts for the vaults after reconnecting to the server or cloud storage.
-```
+:::
 
 ## References
 

--- a/cyberduck/bookmarks.md
+++ b/cyberduck/bookmarks.md
@@ -1,25 +1,25 @@
 Bookmarks
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Toggle Bookmarks
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 You can toggle between the bookmarks and the browser using *Bookmarks → Toggle Bookmarks (`⌘B`)* or by clicking the bookmarks icon in the navigation toolbar. Depending on the bookmark icon size chosen in *Cyberduck → Preferences → General → Bookmarks*, the nickname, URL, username, and comment are shown per bookmark.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 You can toggle between the bookmarks and the browser using *Bookmarks → Toggle Bookmarks (`Strg+B`)* or by clicking the bookmarks icon in the navigation toolbar. Depending on the bookmark icon size chosen in *Edit → Preferences → General → Bookmarks*, the nickname, URL, username, and comment are shown per bookmark.
 
-````
-`````
+:::
+::::
 
 ## Sorting 
 
@@ -31,63 +31,63 @@ Use the search field *(macOS `⌘/` Windows `Strg+F`)* to filter bookmarks by ni
 
 ## Labels & Groups
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 Only supported in Cyberduck for macOS.
-```
+:::
 
 ### Edit Labels for Bookmarks
 
 Assign multiple labels to a bookmark to group them in folders in the menu.
 
-```{image} _images/Edit_Labels_for_Bookmark.png
+:::{image} _images/Edit_Labels_for_Bookmark.png
 :alt: Edit Labels for Bookmark
 :width: 500px
-```
+:::
 
 ### Groups in Bookmarks Menu
 
 Bookmarks are grouped in folders in the menu by their assigned labels. Groups in bookmark view forthcoming.
 
-```{image} _images/Groups_in_Bookmarks_Menu.png
+:::{image} _images/Groups_in_Bookmarks_Menu.png
 :alt: Groups in Bookmarks Menu
 :width: 400px
-```
+:::
 
 ## Add new Bookmark
 
 ### From Current Connection
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 Select *Bookmarks → Toggle Bookmarks (`⌘B`)*. Click the + button in lower left corner to add the server that's currently connected to this browser window to the Bookmarks. An editor window will open where you can adjust the bookmark properties (i.e. nickname) further.
 
-```{image} _images/Add_Bookmark.png
+:::{image} _images/Add_Bookmark.png
 :alt: Add Bookmark
 :width: 400px
-```
+:::
 
 Drag the proxy icon in the browser window title bar to the bookmark drawer or to the *Finder.app*. You can double-click this file in the *Finder.app* to open a new connection.
 
-```{image} _images/Proxy_Icon.png
+:::{image} _images/Proxy_Icon.png
 :alt: Proxy Icon
 :width: 400px
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 Select *Bookmarks → Toggle Bookmarks (`Strg+B`)*. Click the + button in lower left corner to add the server that's currently connected to this browser window to the Bookmarks. An editor window will open where you can adjust the bookmark properties (i.e. nickname) further.
 
-```{image} _images/Add_Bookmark.png
+:::{image} _images/Add_Bookmark.png
 :alt: Add Bookmark
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### From a Third-Party Application
 
@@ -97,10 +97,10 @@ Drag an URL from a third-party application to the bookmark table to create a new
 
 Select *Bookmark → Edit Bookmark (macOS `⌘E` Windows `Strg+E`)*. A panel where you can edit the bookmark's properties will appear. If the server configured is not reachable, an alert icon is displayed next to the URL. Clicking it opens *Network Diagnostics*.
 
-```{image} _images/WebDAV_Bookmark_Client_Certificate.png
+:::{image} _images/WebDAV_Bookmark_Client_Certificate.png
 :alt: WebDAV Bookmark Client Certificate
 :width: 600px
-```
+:::
 
 ### Bookmark Options
 
@@ -121,18 +121,18 @@ Select *Bookmark → Edit Bookmark (macOS `⌘E` Windows `Strg+E`)*. A panel whe
 
 ### Passwords
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Manage your passwords with *Keychain Access.app*. Refer to [Keychain for Mac: Kexchain Access overview](https://support.apple.com/kb/PH20093?locale=en_US).
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Passwords are saved in the *Credential Manager*. You can view and delete your saved login information in *Control Panel → User Accounts → Credential Manager → Windows Credentials*.
 
-````
-`````
+:::
+::::
 
 ## HTTP URL
 
@@ -148,28 +148,27 @@ Example configuration:
 | Selected File | `/home/dkocher/public_html/stylsheet.css` | *A file selected in the browser* |
 | HTTP URL | [http://sudo.ch/stylesheet.css](http://sudo.ch/stylesheet.css) | *Accessible in the web browser* |
 
-```{image} _images/HTTP_URL.png
+:::{image} _images/HTTP_URL.png
 :alt: HTTP URL
 :width: 600px
-```
+:::
 
 Web URLs are supported for [FTP](../protocols/ftp.md), [SFTP](../protocols/sftp/index.md) and [WebDAV](../protocols/webdav/index.md). 
 
 See also [Open or copy HTTP URL](browser.md#open-or-copy-http-url).
 
-
 ## Exporting Bookmarks
 
 Drag the bookmark from the Bookmark Drawer anywhere to the *Finder.app/ Explorer* (e.g. the Desktop). You can double-click the document in the file browser to open a new connection to the server specified in the bookmark. To back up all bookmarks, refer to [this FAQ entry](faq.md#preferences-and-application-support-files-location).
 
-```{image} _images/Drag_Bookmark.png
+:::{image} _images/Drag_Bookmark.png
 :alt: Drag Bookmark
 :width: 300px
-```
+:::
 
-```{note}
+:::{note}
 You can share bookmarks between Mac & Windows as the file format is the same on both platforms.
-```
+:::
 
 ## Importing Bookmarks
 
@@ -204,22 +203,22 @@ You are asked if you want to import bookmarks from the following list of applica
 - *Total Commander*
 - *Cloud Mounter* from `~/Library/Preferences/com.eltima.cloudmounter.plist`
 
-```{image} _images/Filezilla_Import.png
+:::{image} _images/Filezilla_Import.png
 :alt: FileZilla Import
 :width: 600px
-```
+:::
 
 ## Sharing Bookmarks Between Different Computers
 
 You can share bookmarks between different computers and users by uploading the *Bookmarks* and *Profiles* folder to a Cloud Storage of your liking and creating a symbolic link to it.
 
-```{warning}
+:::{warning}
 This only works properly while using the standalone version of Cyberduck or Mountain Duck. The App Store version is unable to list the existing bookmarks from the symbolic link. 
-```
+:::
 
 **Step by Step Instructions Using Dropbox as an Example:**</br>
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 1. Install the Dropbox app, log into your Dropbox account and synchronize the folder where you want to have the bookmarks to the local disk.
 2. Quit *Cyberduck* and/or *Mountain Duck*.
@@ -227,8 +226,8 @@ This only works properly while using the standalone version of Cyberduck or Moun
 4. Open *Terminal.app* and execute the command `ln -s <CloudDirectory> <AppSupportDirectory/foldername>` to create the symbolic link.
 e.g.: `ln -s ~/Dropbox/Bookmarks ~/Library/Group\ Containers/G69SCX94XU.duck/Library/Application\ Support/duck/Bookmarks`
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 1. Install the Dropbox app, log into your Dropbox account and synchronize the folder where you want to have the bookmarks to the local disk.
 2. Quit *Cyberduck* and/or *Mountain Duck*.
@@ -237,8 +236,8 @@ e.g.: `ln -s ~/Dropbox/Bookmarks ~/Library/Group\ Containers/G69SCX94XU.duck/Lib
 	- Open *CMD* and execute the command `mklink /J <AppSupportDirectory\foldername> <CloudDirectory>`.
 	- Open *PowerShell* and execute the command `New-Item -Type Junction -Target <CloudDirectory> -Path <AppSupportDirectory\foldername>`
 
-````
-`````
+:::
+::::
 
 ## Preferences
 
@@ -250,10 +249,14 @@ Choose a default bookmark to open after opening the application. Choose *Prefere
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). Displayed in the bookmark edit window.
 
-    defaults write ch.sudo.cyberduck bookmark.favicon.download false
+```
+defaults write ch.sudo.cyberduck bookmark.favicon.download false
+```
 
 ### Open Bookmark View after Disconnecting
 
 A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck browser.disconnect.bookmarks.show true
+```
+defaults write ch.sudo.cyberduck browser.disconnect.bookmarks.show true
+```

--- a/cyberduck/browser.md
+++ b/cyberduck/browser.md
@@ -1,40 +1,39 @@
 Browser
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Navigation
 
 ### List and Outline View
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Select *View → as List (`⌘1`)* or *View → as Outline (`⌘2`)* for expandable folders. You can expand and collapse folders using the right and left arrow keys in the outline view.
 
 Navigate into a folder with a double-click *(`⌘↓`)* or one level up by using the ▲ button next to the path-field *(`⌘↑`)*.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 You can expand and collapse folders using the right and left arrow keys in the outline view.
 
 Navigate into a folder with a doubl-click *(`Ctrl+Down`)* or one level up by using the ▲ button next to the path-field *(`Ctrl+Up`)*.
 
-````
-`````
+:::
+::::
 
 ### Tabs
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 Enable tabs by default when choosing *File → New Browser (`⌘N`)* by selecting in System Preferences the checkbox *Dock → Prefer tabs when opening documents: Always*. New browser windows and the transfer window will then be displayed in a single window frame with a tab bar. You can merge windows with *View → Show Tab Bar and Window → Merge all Windows*
-
-```
+:::
 
 ### Spring-Loaded Folders
 
@@ -44,9 +43,9 @@ Spring-loaded folders are a feature that allows you to move a file or even anoth
 
 Use the search field (macOS `⌘/` Windows `Ctrl+F`) to display only files that match the search string in the browser. To search recursively, hit the return key (`⏎`). Only files matching the search or folders with containing files matching the pattern will be displayed in the browser.
 
-```{note}
+:::{note}
 Search is case-insensitive and does look for matching sequences in the filename supporting glob patterns `*` and `?`.
-```
+:::
 
 The following protocols have a server-side index that is used to give fast results without recursively descending into folders.
 
@@ -56,9 +55,9 @@ The following protocols have a server-side index that is used to give fast resul
 - [Backblaze B2](../protocols/b2.md)
 - [Microsoft OneDrive](../protocols/onedrive.md)
 
-```{tip}
+:::{tip}
 You can also search for files by _Version_ where applicable.
-```
+:::
 
 #### Supported Wildcards
 
@@ -117,25 +116,27 @@ The following protocols support server-sided copying without intermediate downlo
 
 You can copy files between arbitrary servers when connected to with two open browser windows. Drag files from one browser to the other to transfer files between servers.
 
-```{image} _images/Copy.png
+:::{image} _images/Copy.png
 :alt: Copy
 :width: 700px
-```
+:::
 
 ### Rename a File or Folder
 
 Select the file in the browser and press the *Return key*. Type the new name and press *Return* again to exit the editing mode. You can also rename files by choosing *File → Info (macOS `⌘I` Windows `Alt+Return`)* or press the *Get [Info](info.md)* toolbar button. Simply enter the new name in the very top field. The field must lose focus (e.g. by hitting Return or Tab) to commit the filename change.
 
-```{image} _images/Inline_Rename.png
+:::{image} _images/Inline_Rename.png
 :alt: Inline Rename
 :width: 300px
-```
+:::
 
 ### Deleting Files and Folders
 
 Some protocols support the trashing of files instead of permanently deleting them.  This feature is enabled by default. It can be disabled using a [hidden configuration option](preferences.md#hidden-configuration-options).
 
-	browser.delete.trash=false
+```
+browser.delete.trash=false
+```
 
 This is supported for the following protocols: 
 - [Google Drive](../protocols/googledrive.md)
@@ -150,17 +151,16 @@ Select the file in the browser and choose *File → Info (macOS `⌘I` Windows `
 
 ### Quick Look
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 You can toggle Quick Look in a Cyberduck browser for any file using *Space Bar*. A preview is rendered depending on a Quick Look Plugin available on your system for the given file type. Many file types like different image formats can be previewed with the bundled plugins in OS X and HTML is even rendered in the Quick Look preview panel.
+:::
 
-```
-
-```{image} _images/quicklook.png
+:::{image} _images/quicklook.png
 :alt: Quicklook
 :width: 500px
-```
+:::
 
 ### Open or Copy HTTP URL
 
@@ -185,22 +185,22 @@ Use the *File → Print* option where you can open a PDF from the browser listin
 
 Folder icons are badged for particular access permissions.
 
-```{image} _images/privatefolderbadge.png
+:::{image} _images/privatefolderbadge.png
 :alt: Private Folder Badge
 :width: 50px
-``` 
+:::
 Folder with no permission to access.
 
-```{image} _images/readonlyfolderbadge.png
+:::{image} _images/readonlyfolderbadge.png
 :alt: Read Only Folder Badge
 :width: 50px
-```
+:::
 Folder with read-only permissions. Uploading or editing files to this folder is not possible.
 
-```{image} _images/dropfolderbadge.png
+:::{image} _images/dropfolderbadge.png
 :alt: Drop folder Badge
 :width: 50px
-```
+:::
 Drop Folder where you can only upload files to but are not allowed to view its content.
 
 ### Versions 
@@ -215,10 +215,10 @@ To revert to a previous version and make it the current, choose *File → Revert
 
 Use *Window → Activity (macOS `⌘0` Windows `Ctrl+0`)* to toggle the activity window. It lists the currently running background tasks at the top and all queued activities subsequently.
 
-```{image} _images/Activity.png
+:::{image} _images/Activity.png
 :alt: Activity
 :width: 500px
-```
+:::
 
 ## Problems
 
@@ -242,17 +242,17 @@ Open new browser window after application launch.
 
 ### Browser → General 
 
-### Browser → General → Show Hidden Files
+#### Browser → General → Show Hidden Files
 
 Display files in the browser that start with `.` and [previous revisions (S3)](../protocols/s3/index.md#versions). Use *View → Show Hidden Files* to toggle the mode of a current browser window.
 
-### Browser → General → Double click opens file in external editor
+#### Browser → General → Double click opens file in external editor
 Open files in a external editor by double-clicking
 
-### Browser → General → Return key selects folder or file to rename
+#### Browser → General → Return key selects folder or file to rename
 Use ⏎ key to select a file or folder for renaming 
 
-### Browser → General → Info window always shows current selection
+#### Browser → General → Info window always shows current selection
 
 Use only one *Info* window which updates with the selection change in the browser. If unchecked, open multiple Info windows to compare files.
 
@@ -262,13 +262,17 @@ Use only one *Info* window which updates with the selection change in the browse
 
 A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck browser.font.size 18
+```
+defaults write ch.sudo.cyberduck browser.font.size 18
+```
 
 ### Duplicate Filename Format
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). Define a different format using 
 
-    defaults write ch.sudo.cyberduck browser.duplicate.format "{0} ({1}){2}"
+```
+defaults write ch.sudo.cyberduck browser.duplicate.format "{0} ({1}){2}"
+```
 
 where the plaseholders will be replaced with
 
@@ -280,30 +284,38 @@ where the plaseholders will be replaced with
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). A confirmation is shown before renaming or moving files.
 
-    defaults write ch.sudo.cyberduck browser.move.confirm true
+```
+defaults write ch.sudo.cyberduck browser.move.confirm true
+```
 
 ### Re-Enable File Listing Limit Prompt
 
 A [hidden configuration option](preferences.md#hidden-configuration-options) can re-enable the file listing limit prompt after dismissing it with enabled *Always* checkbox.
 
-````{tabs}
-
-```{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Open *Terminal.app* and execute the command
 
-	defaults delete ch.sudo.cyberduck browser.list.limit.directory
-and the command
-
-	defaults delete ch.sudo.cyberduck browser.list.limit.container
+```
+defaults delete ch.sudo.cyberduck browser.list.limit.directory
 ```
 
-```{group-tab} Windows
+and the command
+
+```
+defaults delete ch.sudo.cyberduck browser.list.limit.container
+```
+
+:::
+:::{group-tab} Windows
 
 Navigate to `%AppData%\Cyberduck` and search within the existing `Cyberduck.exe_Url_<random characters>` folders after the folder that is named after your currently used Cyberduck version. Open the file *user.config* that is located within that folder and delete the lines
 
-	<setting name="browser.list.limit.directory"
-	<setting name="browser.list.limit.container"
+```
+<setting name="browser.list.limit.directory"
+<setting name="browser.list.limit.container"
 ```
 
-````
+:::
+::::

--- a/cyberduck/connection.md
+++ b/cyberduck/connection.md
@@ -1,10 +1,10 @@
 Opening Connections
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Supported Protocols
 
@@ -14,23 +14,23 @@ All major server and cloud storage [protocols](../protocols/index.md) are suppor
 
 Click the *New Connection* toolbar button or *File → Open Connection.. (mac `⌘O` Windows `Strg+O`)*. If you want to open a connection in a new browser window, choose *File → New Browser (macOS `⌘N` Windows `Strg+N`)* first.
 
-```{image} _images/Open_Connection.png
+:::{image} _images/Open_Connection.png
 :alt: Open Connection
 :width: 500px
-```
+:::
 
-```{tip}
+:::{tip}
 Create a new [bookmark](bookmarks.md) instead if you need to configure [additional options](bookmarks.md#bookmark-options) like _Path_. 
-```
+:::
 
 ## Quick Connect
 
 Type in the name of the server directly into the *Quick Connect* field in the toolbar. The text field will autocomplete from [bookmarked](bookmarks.md) hosts. You can enter a string in the format `user@host`, i.e. `user@example.net`, or a fully qualified URL such as `ftp://mirror.switch.ch/mirror/`. Refer to valid [URI](../cli/index.md#uri) formats for input.
 
-```{image} _images/Quick_Connect.png
+:::{image} _images/Quick_Connect.png
 :alt: Quick Connect
 :width: 400px
-```
+:::
 
 If you enter just the hostname, the default protocol as configured in *Preferences → General → Connection* will be used.
 
@@ -44,10 +44,10 @@ Additionally, you can switch to the *History* or *Bonjour* in the bookmark view.
 
 List all recently connected servers. Select a bookmark from the menu *Bookmark → History* or the *History* tab of the bookmark view.
 
-```{image} _images/History_Menu.png
+:::{image} _images/History_Menu.png
 :alt: History Menu
 :width: 700px
-```
+:::
 
 ### Bonjour
 
@@ -57,10 +57,10 @@ Auto-discovery of SFTP, FTP & WebDAV services in your local network. Discovered 
 
 ### Bookmark File
 
-```{image} _images/Bookmark_Files.png
+:::{image} _images/Bookmark_Files.png
 :alt: Bookmark Files
 :width: 200px
-```
+:::
 
 Double-click a Cyberduck `.duck` bookmark file in the *Finder.app*.
 
@@ -70,9 +70,9 @@ Double-click an *Internet Location File* in the *Finder.app*. Cyberduck must be 
 
 ### Use [Spotlight](spotlight.md)
 
-```{note}
+:::{note}
 The *Spotlight Menu* does return no results for recently connected servers in Cyberduck because it excludes indexed files located in `~/Library/Application Support/Cyberduck/History`. This is also an issue for Adium.
-```
+:::
 
 As a workaround, you have to export all bookmarks to another location such as your *Documents* folder. Select all bookmarks *(`⌘A`)* in the bookmark list and drag these somewhere in your *Documents* folder in the Finder. You can then search bookmarks in the *Spotlight Menu* by nickname and hostname. Additionally, to display all bookmarks as a result search for `kind:"Cyberduck Bookmark"`.
 
@@ -113,18 +113,18 @@ A warning sign next to the URL indicates the server may not be reachable due to 
 
 ## Passwords
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Manage your password with *Keychain Access.app* on Mac. Refer to [Keychain for Mac: Keychain Access overview](https://support.apple.com/guide/keychain-access/ky1083/mac).
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Passwords are saved in the *Credential Manager*. You can view and delete your saved login information in *Control Panel → User Accounts → Credential Manager → Windows Credentials*.
 
-````
-`````
+:::
+::::
 
 ## Transcript
 
@@ -137,8 +137,8 @@ The following proxies are supported:
 - SOCKS Proxy for all connections.
 - HTTP proxy tunneling using CONNECT for all connections.
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 The following proxy settings in *System Preferences → Network* are supported:
 
@@ -152,13 +152,13 @@ The *Automatic Proxy Configuration* using a *Proxy Configuration File* is curren
 
 Choose *FTP Proxy* and select the checkbox to configure the proxy address.
 
-```{image} _images/Proxy_Configuration_FTP_and_SFTP.png
+:::{image} _images/Proxy_Configuration_FTP_and_SFTP.png
 :alt: Proxy Configuration FTP/SFTP
 :width: 500px
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 All proxy settings in Internet Explorer *Tools → Internet Options → Connections tab → LAN Settings* button are supported. Refer to [Change proxy server settings in Internet Explorer](https://docs.microsoft.com/troubleshoot/browsers/use-proxy-server-with-ie).
 
@@ -166,8 +166,8 @@ All proxy settings in Internet Explorer *Tools → Internet Options → Connecti
 
 Integrated Windows Authentication (IWA) for proxy authentication of HTTP connections is supported.
 
-````
-`````
+::::
+:::::
 
 ## Preferences
 
@@ -175,9 +175,9 @@ Integrated Windows Authentication (IWA) for proxy authentication of HTTP connect
 
 Select connection protocols to be installed in addition to the default protocols. The connection profile will be installed after enabling the corresponding checkbox. To disable a connection profile simply uncheck the checkbox. The profile will be disabled after closing the application.
 
-```{note}
+:::{note}
 You cannot disable default protocols or connection profiles currently in use in any bookmark.
-```
+:::
 
 ### Connection
 
@@ -203,28 +203,34 @@ Choose *Cyberduck → Preferences → Connection → Use system proxy settings*.
 
 A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck connection.dns.ipv6 true
+```
+defaults write ch.sudo.cyberduck connection.dns.ipv6 true
+```
 
 #### Disable Bonjour Support
 
 A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck rendezvous.enable false
+```
+defaults write ch.sudo.cyberduck rendezvous.enable false
+```
 
 #### Disable Bonjour Notifications in Notification Center and System Tray
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). By default, the limit is set to allow not more than `30` notifications per minute.
 
-    defaults write ch.sudo.cyberduck rendezvous.notification.limit 0
+```
+defaults write ch.sudo.cyberduck rendezvous.notification.limit 0
+```
 
 ## Default Protocol Handler
 
 You can set Cyberduck or a third-party application as the default application (protocol handler) for `FTP` and `SFTP` in *Preferences → FTP* and *Preferences → SFTP* respectively.
 
-```{image} _images/Default_FTP_Protocol_Handler.png
+:::{image} _images/Default_FTP_Protocol_Handler.png
 :alt: Default FTP Protocol Handler
 :width: 400px
-```
+:::
 
 ### Web Browser
 
@@ -232,11 +238,11 @@ When you click URLs in another application like your web browser, this applicati
 
 ### Terminal
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 This also works when working in *Terminal.app*. Type open `sftp://host` to open with Cyberduck registered as the default protocol handler for SFTP.
-```
+:::
 
 ### Installation
 

--- a/cyberduck/copy.md
+++ b/cyberduck/copy.md
@@ -19,6 +19,6 @@ This is supported for the following protocols
 
 [FTP](../protocols/ftp.md) and [SFTP](../protocols/sftp/index.md) do not support a copy operation. 
 
-```{important}
+:::{important}
 Transfer speed depends on your local connectivity as files are routed through your computer for transfer between the remote servers.
-```
+:::

--- a/cyberduck/download.md
+++ b/cyberduck/download.md
@@ -9,9 +9,9 @@ Increase the download speed by enabling the segmented downloads option within *P
 
 The segments will be merged automatically after all parts are downloaded. Merging the segments may take a considerable amount of time.
 
-```{note}
+:::{note}
 The segments can only be merged successfully if all parts are downloaded. If some parts are missing the downloaded segments are saved within a folder and the file can't be restored unless you redownload the file or try to _Resume_ the failed transfer.
-```
+:::
 
 ## Double-Click
 
@@ -25,10 +25,10 @@ Drag the files or folders to the desired download location in the *Finder.app* o
 
 Customize the browser toolbar using menu *View → Customize Toolbar...* to add the *Download* toolbar button to the default configuration.
 
-```{image} _images/Download_Toolbar_Button.png
+:::{image} _images/Download_Toolbar_Button.png
 :alt: Download Toolbar Button
 :width: 500px
-```
+:::
 
 ## The Download Menu
 
@@ -40,30 +40,34 @@ Drag the file from the browser to the *Transfers* window to be downloaded later.
 
 ## Where From 
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: note
 
 Downloaded files have added metadata of its origin URL. *Finder.app* displays this information in *File → Get Info*.
-```
+:::
 
 ## Hidden Preferences
 
 ### Quarantine
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: note
 
 Downloaded files are flagged with the `com.apple.quarantine` attribute. The attributes associate basic information with the file, such as its type, when it was received, and the URL from which it came. When the Finder or any other program uses Launch Services to open a quarantined file, Launch Services inspects the file to see if it appears to be an application, script, or other executable file types. If so, the system displays an alert informing the user that the file is an application and asking for confirmation that it should be executed. The alert lets the user open the URL from which the file was downloaded, launch the program, or cancel. If the user proceeds to open the file, Launch Services removes the quarantine attributes from that file.
 
 A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck queue.download.quarantine false
+```
+defaults write ch.sudo.cyberduck queue.download.quarantine false
+```
 
 Files downloaded to edit do not have a quarantine flag set by default.
-```
+:::
 
 ### Temporary Document Icon
 
 Don't change the document icon while downloading. A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck queue.download.icon.update false
+```
+defaults write ch.sudo.cyberduck queue.download.icon.update false
+```

--- a/cyberduck/edit.md
+++ b/cyberduck/edit.md
@@ -6,35 +6,38 @@ You can edit a file just as a local file in an external editor by clicking the E
 ## Default Editor
 The default editor opened for a file is selected depending on the file type. If no application is found to handle the file type the default editor chosen in *Preferences* is used instead.
 
-```{image} _images/Edit_With_Application.png
+:::{image} _images/Edit_With_Application.png
 :alt: Edit with Application
 :width: 700px
-```
+:::
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
+
 To edit file type associations choose *File → Info* for a given file type in the *Finder.app*.
-```
-```{admonition} Windows only
+:::
+
+:::{admonition} Windows only
 :class: tip
+
 To edit file type associations choose *Properties → General → Type of file → Change…* for a given file type in Windows Explorer.
-```
+:::
 
 ## Preferences
 
 ### Default Editor
 Set your preferred editor in *Preferences*. Select *Always use default editor* in *Preferences → Editor* if you always want to use the default editor set regardless of the file type.
 
-```{image} _images/Editor_Preferences.png
+:::{image} _images/Editor_Preferences.png
 :alt: Editor Preferences
 :width: 700px
-```
+:::
 
 ### Versioning
 
-```{important}
+:::{important}
 Cyberduck [9.0](https://cyberduck.io/changelog/) or later required
-```
+:::
 
 Enable the custom versioning option in *Preferences → Editor* to store previous versions of a file. The versions can be previewed, deleted or restored in the *File → Info → Versions* tab of the *[Info](../cyberduck/info.md#versions)* window. The feature only applies for protocols without native versioning like [FTP](../protocols/ftp.md)/[SFTP](../protocols/sftp/index.md), [WebDAV](../protocols/webdav/index.md), [SMB](../protocols/smb.md), [OpenStack Swift](../protocols/openstack/index.md). The file versions are stored in a hidden folder named `.duckversions` in each folder on the mount. The versions are named with a pattern like `filename.extension → filename-20230906102017.762.extension`.
 
@@ -44,13 +47,17 @@ Enable the custom versioning option in *Preferences → Editor* to store previou
 
 A [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    defaults write ch.sudo.cyberduck editor.upload.temporary false
+```
+defaults write ch.sudo.cyberduck editor.upload.temporary false
+```
 
 ### Exclude Files from Versioning
 
 Files can be excluded from versioning by using a [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    versioning.include.regex=.*
+```
+versioning.include.regex=.*
+```
 
 ### Number of Saved Versions
 
@@ -58,18 +65,18 @@ Per default, the number of saved versions is limited to 5. The oldest version wi
 
 The number of saved versions can be customized by using a [hidden configuration option](preferences.md#hidden-configuration-options).
 
-    versioning.limit=5
-
+```
+versioning.limit=5
+```
 
 ## Problems
 
 ### No External Editor Available
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 If the editor does not show up as a choice in *File → Edit With* (the only submenu item is *No external editor available*), you may have to rebuild the `LaunchServices`database of OS X using Terminal.app:
 
 `/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister \ -kill -r -domain local -domain system -domain user`
-
-```
+:::

--- a/cyberduck/faq.md
+++ b/cyberduck/faq.md
@@ -1,10 +1,10 @@
 FAQ
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## General
 
@@ -16,10 +16,10 @@ Cyberduck is an open-source server and cloud storage browser for Mac and Windows
 
 Cyberduck is free software. Free software is a matter of the users' freedom to run, copy, distribute, study, change, and improve the software. If you find this program useful, please consider making a [donation](http://cyberduck.ch/donate). A donation would not only demonstrate your appreciation of this software but also help to advance development in the future. You receive a registration key and it will help to make Cyberduck even better!
 
-```{image} _images/Donation_Prompt.png
+:::{image} _images/Donation_Prompt.png
 :alt: Donation Prompt
 :width: 600px
-```
+:::
 
 #### What Payment Options are Available?
 
@@ -88,8 +88,8 @@ The registration key is sent to you by email automatically after the Paypal tran
 
 ### Preferences and Application Support Files Location
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Preferences are saved in `~/Library/Preferences/ch.sudo.cyberduck.plist`. Bookmarks, history, and [connection profiles](../protocols/profiles/index.md) are saved in the application support directory. These settings are shared with [Cyberduck CLI](../cli/index.md) and [Mountain Duck](../mountainduck/index.md).
 
@@ -97,8 +97,8 @@ Preferences are saved in `~/Library/Preferences/ch.sudo.cyberduck.plist`. Bookma
 
 Navigate to the *Library* folder using `⌘⇧-L` or use *Go → Go to Folder...* in Finder.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Bookmarks, history, [connection profiles](../protocols/profiles/index.md), and workspace information are saved in the application data directory. You can navigate to the `AppData` folder by opening a *File Explorer* window and paste `%AppData%\Cyberduck` in the Quick access location field.
 
@@ -110,8 +110,8 @@ For the Windows Store version refer to
 
 Preferences are stored in `%AppData%\Cyberduck\cyberduck.user.config`. Please note that settings in `%AppData%\Cyberduck\default.properties` takes precedence over `user.config`.
 
-````
-`````
+:::
+::::
 
 ## Where can I Issue Bug Reports and Feature Requests?
 

--- a/cyberduck/index.md
+++ b/cyberduck/index.md
@@ -1,7 +1,7 @@
 Cyberduck 
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 installation
@@ -21,21 +21,21 @@ notifications
 spotlight
 support
 faq
-```
+:::
 
 ## Quick Reference Cheat Sheet
 
 Download the {download}`Cyberduck Quick Reference<https://trac.cyberduck.io/raw-attachment/wiki/help/en/howto/cyberduck/Cyberduck%20Quick%20Reference.pdf>` PDF.
 
-```{image} _images/Cyberduck_Quick_Reference_Page_1.png
+:::{image} _images/Cyberduck_Quick_Reference_Page_1.png
 :alt: Cyberduck Quick Reference Page 1
 :width: 700px
-```
+:::
 
-```{image} _images/Cyberduck_Quick_Reference_Page_2.png
+:::{image} _images/Cyberduck_Quick_Reference_Page_2.png
 :alt: Cyberduck Quick Reference Page 2
 :width: 700px
-```
+:::
 
 ## [Opening Connections](connection.md)
 

--- a/cyberduck/info.md
+++ b/cyberduck/info.md
@@ -1,23 +1,23 @@
 Info Window
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
-````{tabs}
-```{group-tab} Cyberduck
+::::{tabs}
+:::{group-tab} Cyberduck
 
 Select the file in the browser and choose *File → Info (macOS `⌘I` Windows `Alt+Return`)* to display detailed information on a file in a tool window. You can choose in the [Preferences](preferences.md) in the *Browser* tab to use the info window as an inspector of the currently selected files in the browser or open a new panel window to compare different files.
 
-```
-```{group-tab} Mountain Duck
+:::
+:::{group-tab} Mountain Duck
 
 Select a file or folder within the Finder and choose *Mountain Duck → Info* from the context menu to display detailed information on the selected content in a tool window.
 
-```
-````
+:::
+::::
 
 ## General
 
@@ -25,10 +25,10 @@ Select a file or folder within the Finder and choose *Mountain Duck → Info* fr
 
 Type in the new filename and press *Tab* to leave the text field and commit the change.
 
-```{image} _images/General.png
+:::{image} _images/General.png
 :alt: General
 :width: 600px
-```
+:::
 
 ### Calculate Folder Size
 
@@ -36,27 +36,24 @@ Calculate the size recursively of all contained files.
 
 ## Versions
 
-```{important}
+:::{important}
 Cyberduck [8.4](https://cyberduck.io/changelog/) or later required
-```
+:::
 
-A list of file versions can be viewed in the *Versions* tab of the Info window. The following actions are available for
-a selected previous version:
+A list of file versions can be viewed in the *Versions* tab of the Info window. The following actions are available for a selected previous version:
 
 - Revert version
 - Permanently delete version
-- View previous version. On macOS, this opens a *QuickLook* window. On Windows, this downloads and opens the file in the
-  default editor.
+- View previous version. On macOS, this opens a *QuickLook* window. On Windows, this downloads and opens the file in the default editor.
 
 The list is empty when no previous version is available.
 
-```{image} _images/Info_Panel_Versions.png
+:::{image} _images/Info_Panel_Versions.png
 :alt: Versions Tab
 :width: 600px
-```
+:::
 
-The following protocols support to view previous versions of files. Some protocols also display previous versions of
-files in [browser](../cyberduck/browser.md) when enabling *View → Show Hidden*.
+The following protocols support to view previous versions of files. Some protocols also display previous versions of files in [browser](../cyberduck/browser.md) when enabling *View → Show Hidden*.
 
 | **Protocol**                                                 | **Revert previous version** | **Open/Quick Look previous version** | **Delete version** | **Displayed in browser with *View → Show Hidden*** |
 |--------------------------------------------------------------|-----------------------------|--------------------------------------|--------------------|----------------------------------------------------|
@@ -74,113 +71,92 @@ files in [browser](../cyberduck/browser.md) when enabling *View → Show Hidden*
 | **[WebDAV](../protocols/webdav/index.md)**                   | ✅                           | ✅                                    | ✅                  | ❌                                                  |
 | **[SMB](../protocols/smb.md)**                               | ✅                           | ✅                                    | ✅                  | ❌                                                  |
 
-```{note}
+:::{note}
 Using [S3](../protocols/s3/index.md) or [Backblaze B2](../protocols/b2.md), versions will only be displayed if bucket versioning is enabled.
-```
+:::
 
-```{important}
+:::{important}
 Enable _Versioning_ in *Preferences → Editor* to view revisions of edited files for protocols with no native versioning support.
-```
+:::
 
 ## UNIX Permissions
 
-Change the permissions on a particular file or folder when connected to a [FTP](../protocols/ftp.md)
-or [SFTP](../protocols/sftp/index.md) server. You can also select multiple files in the browser to edit permissions.
-Click the checkboxes or enter
-the [octal notation](http://en.wikipedia.org/wiki/File_system_permissions#Symbolic_notation). The recursive options will
-update all files within a folder but will not change the executable bit for files if not already set when recursively
-updating a directory.
+Change the permissions on a particular file or folder when connected to a [FTP](../protocols/ftp.md) or [SFTP](../protocols/sftp/index.md) server. You can also select multiple files in the browser to edit permissions.
+Click the checkboxes or enter the [octal notation](http://en.wikipedia.org/wiki/File_system_permissions#Symbolic_notation). The recursive options will update all files within a folder but will not change the executable bit for files if not already set when recursively updating a directory.
 
-```{image} _images/UNIX_Permissions.png
+:::{image} _images/UNIX_Permissions.png
 :alt: UNIX Permissions
 :width: 400px
-```
+:::
 
 ## Access Control List (ACL)
 
-Edit access control list for fine grained user permissions when connected to [Amazon S3](../protocols/s3/index.md)
-or [Google Cloud Storage](../protocols/googlecloudstorage.md).
+Edit access control list for fine grained user permissions when connected to [Amazon S3](../protocols/s3/index.md) or [Google Cloud Storage](../protocols/googlecloudstorage.md).
 
 - [S3 ACLs](../protocols/s3/index.md#access-control-acl)
 - [Google Storage ACLs](../protocols/googlecloudstorage.md#acls)
 
-```{image} _images/Access_Control_Lists.png
+:::{image} _images/Access_Control_Lists.png
 :alt: Access Control Lists
 :width: 500px
-```
+:::
 
 ## CDN Panel
 
-Manage [Amazon CloudFront](../protocols/cdn/cloudfront.md) and [Rackspace/Akamai](../protocols/cdn/akamai.md)
-distributions ([CDN](../protocols/cdn/index.md)) respectively.
+Manage [Amazon CloudFront](../protocols/cdn/cloudfront.md) and [Rackspace/Akamai](../protocols/cdn/akamai.md) distributions ([CDN](../protocols/cdn/index.md)) respectively.
 
 ### Deployment Status
 
-Upon changing configuration parameters of a distribution configuration, the settings are not distributed immediately in
-the CDN. While the deployment is in progress (which can take up to 15 minutes), the status *In Progress* is displayed.
-The updates are fully propagated throughout the CloudFront system when the distribution's state switches from *In
-Progress* to *Deployed*.
+Upon changing configuration parameters of a distribution configuration, the settings are not distributed immediately in the CDN. While the deployment is in progress (which can take up to 15 minutes), the status *In Progress* is displayed.
+The updates are fully propagated throughout the CloudFront system when the distribution's state switches from *In Progress* to *Deployed*.
 
 ### CloudFront Access Logging
 
-When this option is enabled, access logs are written to `<bucketname>/logs`. The changes to the logging configuration
-take effect within 12 hours. The logging option is supported for both download and streaming distributions. Choose the
-target bucket for access logs in the dropdown menu listing all buckets of your account. It is considered best practice
-to choose a different logging target for each distribution.
+When this option is enabled, access logs are written to `<bucketname>/logs`. The changes to the logging configuration take effect within 12 hours. The logging option is supported for both download and streaming distributions. Choose the target bucket for access logs in the dropdown menu listing all buckets of your account. It is considered best practice to choose a different logging target for each distribution.
 
 ### Origin
 
-The source of the content where CloudFront fetches the content to be served in the edge location of the CDN. This is
-a [S3](../protocols/s3/index) bucket or your custom origin.
+The source of the content where CloudFront fetches the content to be served in the edge location of the CDN. This is a [S3](../protocols/s3/index) bucket or your custom origin.
 
 ### Where
 
-The `cloudfront.net` domain assigned to your distribution. This is directing to the edge location in the CDN next to the
-user requesting an URL.
+The `cloudfront.net` domain assigned to your distribution. This is directing to the edge location in the CDN next to the user requesting an URL.
 
 ### CNAMEs
 
-Enter a [CNAME](http://en.wikipedia.org/wiki/CNAME_record) (alias in the Domain Name System) for the hostname of the
-distribution given by CloudFront. To use multiple CNAMEs for a single distribution, the hostnames must be space
-delimited. The CNAME must be registered on the nameserver responsible for your domain and point to `cloudfront.net`
-domain assigned to your distribution.
+Enter a [CNAME](http://en.wikipedia.org/wiki/CNAME_record) (alias in the Domain Name System) for the hostname of the distribution given by CloudFront. To use multiple CNAMEs for a single distribution, the hostnames must be space delimited. The CNAME must be registered on the nameserver responsible for your domain and point to `cloudfront.net` domain assigned to your distribution.
 
 Example configuration:
 
-	;; QUESTION SECTION:
-	;cdn.cyberduck.ch.		IN	A
-	
-	;; ANSWER SECTION:
-	cdn.cyberduck.ch.	1576	IN	CNAME	d15bfu8of7vup8.cloudfront.net.
+```
+;; QUESTION SECTION:
+;cdn.cyberduck.ch.		IN	A
+
+;; ANSWER SECTION:
+cdn.cyberduck.ch.	1576	IN	CNAME	d15bfu8of7vup8.cloudfront.net.
+```
 
 ### Index File
 
-You can assign a default root object to your HTTP or HTTPS distribution. This default object will be served when Amazon
-CloudFront receives a request for the root of your distribution – i.e., your distribution’s domain name by itself.
+You can assign a default root object to your HTTP or HTTPS distribution. This default object will be served when Amazon CloudFront receives a request for the root of your distribution – i.e., your distribution’s domain name by itself.
 
-When you define a default root object, a user request that calls the root of your distribution returns the default root
-object. For example, if you designate the file `index.html` as your default root object, a request
-for `http://d604721fxaaqy9.cloudfront.net/` returns `http://d604721fxaaqy9.cloudfront.net/index.html`.
+When you define a default root object, a user request that calls the root of your distribution returns the default root object. For example, if you designate the file `index.html` as your default root object, a request for `http://d604721fxaaqy9.cloudfront.net/` returns `http://d604721fxaaqy9.cloudfront.net/index.html`.
 
 ### Object Invalidation
 
-[Invalidation](http://aws.amazon.com/about-aws/whats-new/2010/08/31/cloudfront-adds-invalidation-feature/) is one way to
-remove a distribution object from an edge server cache before the expiration setting on the object's header.
-Invalidation clears the object from the edge server cache, and a subsequent request for the object will cause CloudFront
-to return to the origin to fetch the latest version of the object.
+[Invalidation](http://aws.amazon.com/about-aws/whats-new/2010/08/31/cloudfront-adds-invalidation-feature/) is one way to remove a distribution object from an edge server cache before the expiration setting on the object's header.
+Invalidation clears the object from the edge server cache, and a subsequent request for the object will cause CloudFront to return to the origin to fetch the latest version of the object.
 
-```{note}
+:::{note}
 Use the Invalidate option *File → Info → Distribution (CDN)* to invalidate files from edge locations.
-```
+:::
 
 ## Provider Panel
 
-Settings specific for the cloud service in use. Available
-for [Amazon S3](../protocols/s3/index.md), [Backblaze B2](../protocols/b2.md), [Windows Azure Blob Storage](../protocols/azure.md),
-and [Google Cloud Storage](../protocols/googlecloudstorage.md).
+Settings specific for the cloud service in use. Available for [Amazon S3](../protocols/s3/index.md), [Backblaze B2](../protocols/b2.md), [Windows Azure Blob Storage](../protocols/azure.md), and [Google Cloud Storage](../protocols/googlecloudstorage.md).
 
-``````{tabs}
-`````{group-tab} Amazon S3
+:::::{tabs}
+::::{group-tab} Amazon S3
 
 - The geographic location of the bucket.
 - [Publicly accessible URL](../protocols/s3/index.md#pre-signed-temporary-urls) to the file with a validity of 24 hours. Signed URLs with a different life are available in the *Edit → Copy URL* menu.
@@ -190,36 +166,36 @@ and [Google Cloud Storage](../protocols/googlecloudstorage.md).
 - Configure [Multi-Factor Authentication (MFA) Delete](../protocols/s3/index.md#multi-factor-authentication-mfa-delete).
 - Configure [Transfer Acceleration](../protocols/s3/index.md#transfer-acceleration).
 
-```{image} _images/Amazon_S3.png
+:::{image} _images/Amazon_S3.png
 :alt: Amazon S3
 :width: 500px
-```
+:::
 
-`````
-`````{group-tab} Windows Azure Blob Storage
+::::
+::::{group-tab} Windows Azure Blob Storage
 
 - [Publicly accessible URL](../protocols/azure.md#shared-access-signature-urls) to the file with a validity of 24 hours. Signed URLs with a different life are available in the *Edit → Copy URL* menu.
 - Enabling [access logs](../protocols/azure.md#access-logs) for the bucket.
 
-```{image} ../protocols/_images/Azure_tab_info_macOS.png
+:::{image} ../protocols/_images/Azure_tab_info_macOS.png
 :alt: Windows Azure Blob Storage
 :width: 500px
-```
+:::
 
-`````
-`````{group-tab} Backblaze B2
+::::
+::::{group-tab} Backblaze B2
 
 - [Publicly accessible URL](../protocols/b2.md#authorized-url) to the file with a validity of 7 days.
 - Configure [bucket versioning](../protocols/b2.md#file-versioning).
 
 
-```{image} ../protocols/_images/B2_tab_info_macOS.png
+:::{image} ../protocols/_images/B2_tab_info_macOS.png
 :alt: Backblaze B2
 :width: 500px
-```
+:::
 
-`````
-`````{group-tab} Google Cloud Storage
+::::
+::::{group-tab} Google Cloud Storage
 
 - The geographic location of the bucket.
 - Enabling [access logs](../protocols/googlecloudstorage.md#bucket-access-logging) for the bucket.
@@ -227,26 +203,25 @@ and [Google Cloud Storage](../protocols/googlecloudstorage.md).
 - Configure [bucket versioning](../protocols/googlecloudstorage.md#versioning).
 - Configure Transfer Acceleration.
 
-```{image} ../protocols/_images/GCS_tab_info_macOS.png
+:::{image} ../protocols/_images/GCS_tab_info_macOS.png
 :alt: Google Cloud Storage
 :width: 500px
-```
+:::
 
-`````
-``````
+::::
+:::::
 
 ## Metadata (HTTP headers)
 
 View and modify metadata attributes of files.
 
-Any non-standard HTTP header values are (transparently) prefixed with the following values following the guidelines from
-the different providers:
+Any non-standard HTTP header values are (transparently) prefixed with the following values following the guidelines from the different providers:
 
 - Values are prefixed with `x-amz-meta-` for [S3](../protocols/s3/index.md)
   and [Google Storage](../protocols/googlecloudstorage.md).
 - Values are prefixed with `X-Object-Meta-` for [CloudFiles](../protocols/openstack/cloudfiles.md).
 
-```{image} _images/Metadata.png
+:::{image} _images/Metadata.png
 :alt: Metadata
 :width: 500px
-```
+:::

--- a/cyberduck/installation.md
+++ b/cyberduck/installation.md
@@ -1,13 +1,13 @@
 Installation
 ===
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Move the unzipped application bundle *Cyberduck.app* from the *Downloads* to the */Applications* folder on your harddisk.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 **EXE Installer**
 
@@ -23,13 +23,13 @@ Download *MSI Installer* for corporate environments. Requires prior installation
 
 There is also a [Chocolatey](http://chocolatey.org/packages?q=cyberduck) package maintained.
 
-````
-`````
+:::
+::::
 
 ## System Requirements
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 - Cyberduck [8.1](https://trac.cyberduck.io/milestone/8.1) or later requires *Mac OS X 10.12* or later and a [64Bit Intel](http://support.apple.com/kb/ht3696) or [Apple silicon](https://support.apple.com/en-us/HT211814) architecture
 - Cyberduck [7.7](https://trac.cyberduck.io/milestone/7.7.0) or later requires *Mac OS X 10.9* or later and a [64Bit Intel](http://support.apple.com/kb/ht3696) architecture
@@ -41,8 +41,8 @@ There is also a [Chocolatey](http://chocolatey.org/packages?q=cyberduck) package
 - Cyberduck 2.5 or later requires *Mac OS X 10.3.9* or later. The latest version [available](http://cyberduck.ch/changelog) is [2.8.5](http://update.cyberduck.ch/Cyberduck-2.8.5.dmg) supporting *Mac OS X 10.3.9*.
 - Cyberduck 2.3 or later requires *Mac OS X 10.2* or later. The latest version [available](http://cyberduck.ch/changelog) is [2.3.3](http://update.cyberduck.ch/Cyberduck-2.3.3.dmg) supporting *Mac OS X 10.2*.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Requires *.NET Framework 4.7.2*. If the [.NET Framework installation](https://dotnet.microsoft.com/download/dotnet-framework/net472) fails, download it manually.
 
@@ -51,29 +51,27 @@ Requires *.NET Framework 4.7.2*. If the [.NET Framework installation](https://do
 - Cyberduck [4.8](https://trac.cyberduck.io/milestone/4.8) or later requires *Windows Vista* or later.
 - Cyberduck [4.0](https://trac.cyberduck.io/milestone/4.0) or later requires *Windows XP or Windows 7* or later.
 
-````
-`````
+:::
+::::
 
 ## Complete Uninstall
 
 Follow the steps below to uninstall Cyberduck completely.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 1. Close the application and navigate to the application folder using the shortcut `⌘⇧A`. Select *Cyberduck.app* and delete the application by choosing *File → Move to Trash*.
 2. Navigate to the *Group Containers* folder within *~/Library/* and delete the folder *G69SCX94XU.duck*.
 3. **Optional:** Delete all saved login credentials in *Keychain Access.app*.
 
-````
-
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 1. Close the application and open the start menu using the shortcut `Ctrl Esc`. Search for *Apps & Features* and move to the entry *Cyberduck*. Click on the application, choose *Uninstall*, and confirm your intentions by clicking *Uninstall* again.
 2. Navigate to the `%AppData%`and delete the folder *Cyberduck*
 3. Navigate to `%LocalAppData%`and delete the folder *Cyberduck*
 4. **Optional:** Delete all saved login credentials in *Windows Credential Manager*.
 
-````
-
-`````
+:::
+::::

--- a/cyberduck/notifications.md
+++ b/cyberduck/notifications.md
@@ -12,8 +12,8 @@ Notifications
 - Transfer queued
 - Bonjour
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 **Notification Center**
 
@@ -23,16 +23,15 @@ On *OS x 10.8 or later*, notifications are sent to the *Notification Center*.
 
 Notifications can be configured in *System Preferences → Notifications*.
 
-
-```{image} _images/Notification_Center.png
+:::{image} _images/Notification_Center.png
 :alt: Notification Center
 :width: 700px
-```
+:::
 
 The default alert style is *Banner* which is dismissed automatically after some delay. You can change the type to *Alert* if you want to have a *Close* and *Show* button to dismiss the alert manually.
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 **Notification Area**
 
@@ -40,9 +39,10 @@ Notifications are displayed in the notification area commonly referred to as the
 
 **Settings**
 
-```{image} _images/Notifications_Area_Settings.png
+:::{image} _images/Notifications_Area_Settings.png
 :alt: Notification Area Settings
 :width: 700px
-```
-````
-`````
+:::
+
+::::
+:::::

--- a/cyberduck/preferences.md
+++ b/cyberduck/preferences.md
@@ -1,19 +1,21 @@
 Preferences
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
  
 In general, user adjustable preferences are discussed in the context of the topic in all wiki pages.
 
 ## General
 
 ### Save Workspace
+
 Save open connections when quitting and restore when opening the application.
 
 ### Bookmarks
+
 Change the row height of bookmarks displayed in the browser window. Choose between *Small, Medium,* and *Large* icons.
 
 ## [Browser](browser.md)
@@ -60,11 +62,12 @@ Manage general connection settings like the default protocol, timeouts, and prox
 
 Choose whether your [Cryptomator vaults](../cryptomator/index.md) should be auto detected and unlocked while browsing the parent folder or not by using the *Auto detect and open vault in browser* option.
 
-```{note}
+:::{note}
 Without saving the vaults passwords using keychain, you will receive passwords prompts for the vaults after reconnecting to the server or cloud storage.
-``` 
+::: 
 
 ### Use Keychain
+
 Specify if you want the *Save Password* option enabled by default while entering the password to unlock your vault. With the option disabled you have to check the checkbox to save the password in keychain manually. 
 
 ## Language
@@ -73,10 +76,10 @@ Choose the language of the user interface. It defaults to the system language wh
 
 - On macOS, the first matching language is chosen according to the *Languages* list within System *Preferences → International*. To change your preferred language for all applications, change the preset hierarchy.
 
-```{image} _images/Language_Preference.png
+:::{image} _images/Language_Preference.png
 :alt: Send Command
 :width: 500px
-```
+:::
 
 ## Update
 
@@ -86,10 +89,10 @@ An auto update feature will alert you when a new version is available and self u
 
 Snapshot builds include the latest changes and are published regularly. These builds are not tested.
 
-```{image} _images/Update.png
+:::{image} _images/Update.png
 :alt: Update
 :width: 500px
-```
+:::
 
 ### Beta Builds
 
@@ -99,8 +102,8 @@ Beta builds are published before a release and include the latest features and h
 
 There are some settings which aren't yet available in the *Preferences* either because they are not considered stable yet or not of general interest. Follow these steps to enable a hidden preference referenced in the wiki:
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Type the `defaults` command given in a *Terminal.app* (in `/Applications/Utilities`) window and restart Cyberduck.
 
@@ -112,8 +115,8 @@ Alternatively you can create a file `default.properties` in the [application sup
 `<property>=<value>`<br/>
 `...`
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 If not existing yet you need to create the file [%AppData%](faq.md#preferences-and-application-support-files-location)`\Cyberduck\default.properties`. To do that create a new text file within `%AppData%\Cyberduck` and replace the preconfigured name including the file extension by *default.properties*.
 
@@ -122,9 +125,11 @@ Add the setting as follows:
 `...`<br/>
 `<property>=<value>`<br/>
 `...`
-````
-````{group-tab} CLI
+
+:::
+:::{group-tab} CLI
 
 Refer to [Preferences](../cli/index.md#preferences)
-````
-`````
+
+:::
+::::

--- a/cyberduck/share.md
+++ b/cyberduck/share.md
@@ -3,10 +3,10 @@ Share Files
 
 Many storage providers have an option to share a file with a third party without access to your account with a publicly accessible link. Depending on the provider, the link may be auto expiring and no longer valid after a given period or a password can be set required to download the file. Some providers support to _Request files…_ from others by creating an URL that allows others to add files to your account.
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Availability
 
@@ -35,218 +35,218 @@ Providers with support to share a file using a public, password protected or tem
 
 For connections using [S3](../protocols/s3/index.md) protocol, make sure the bucket allows [ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html?icmpid=docs_amazons3_console) and doesn't block [public access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html?icmpid=docs_amazons3_console).
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 * Choose *Edit → Copy URL → Signed URL* to create a [pre-signed temporary](../protocols/s3/index.md#pre-signed-temporary-urls) URL making a private object stored in a S3 bucket publicly available for a limited time.
 * Choose *File → Share…* to change the ACL on the file permanently allowing read for everyone. You can reset the changed ACL in [Info → ACL](../cyberduck/info.md#access-control-list-acl).
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 * Choose *Copy URL* from the [context menu](../mountainduck/interface.md#share) to create a [pre-signed temporary](../protocols/s3/index.md#pre-signed-temporary-urls) URL making a private object stored in a S3 bucket publicly available for a limited time.
 * Choose *Share…* from the [context menu](../mountainduck/interface.md#share) to change the ACL on the file permanently allowing read for everyone. You can reset the changed ACL in [Info → ACL](../cyberduck/info.md#access-control-list-acl).
 
-```{image} ../cyberduck/_images/S3_Pre-Signed_URL.png
+:::{image} ../cyberduck/_images/S3_Pre-Signed_URL.png
 :alt: Pre-Signed URL
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### OpenStack Swift
 
 For connections using [OpenStack Swift](../protocols/openstack/index.md) protocol.
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *Edit → Copy URL → Signed URL* to make a private object stored in OpenStack Swift publicly available for a limited time using a [signed URL](../protocols/openstack/index.md#temporary-urls).
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Choose *Copy URL* from the [context menu](../mountainduck/interface.md#share) to make a private object stored in OpenStack Swift publicly available for a limited time using a [signed URL](../protocols/openstack/index.md#temporary-urls).
 
-````
-`````
+::::
+:::::
 
 ### Azure
 
 For connections to [Azure](../protocols/azure.md). 
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *Edit → Copy URL → Signed URL* to create a [Shared Access Signature URL](../protocols/azure.md#shared-access-signature-urls).
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Choose *Copy URL* from the [context menu](../mountainduck/interface.md#share) to create a [Shared Access Signature URL](../protocols/azure.md#shared-access-signature-urls).
 
-````
-`````
+::::
+:::::
 
 ### Backblaze B2
 
 For connections to [Backblaze B2](../protocols/b2.md).
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *File → Share…* to create an [authorized URL](../protocols/b2.md#authorized-url) to make files available publicly expiring after 7 days.
 
-```{image} ../cyberduck/_images/B2_Authorized_URL.png
+:::{image} ../cyberduck/_images/B2_Authorized_URL.png
 :alt: B2 Authorized URL
 :width: 600px
-```
+:::
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Choose *Share…* from the [context menu](../mountainduck/interface.md#share) to create an [authorized URL](../protocols/b2.md#authorized-url) to make files available publicly expiring after 7 days.
 
-````
-`````
+::::
+:::::
 
 ### DRACOON
 
 For [DRACOON](../protocols/dracoon.md) connections.
 
-`````{tabs}
-````{group-tab} Cyberduck
+::::{tabs}
+:::{group-tab} Cyberduck
 
 Choose *File → Share…* to create an [download share](../protocols/dracoon.md#download-share) for a file or folder. Optionally set a password required to download the file. Choose *Skip* to create a public share with no password protection.
 
-````
-````{group-tab} Mountain Duck
+:::
+:::{group-tab} Mountain Duck
 
 Choose *Share…* from the [context menu](../mountainduck/interface.md#share)  to create an [download share](../protocols/dracoon.md#download-share) for a file or folder.
 
-````
-`````
+:::
+::::
 
 ### OneDrive & Sharepoint
 
 For bookmarks configured with [Microsoft OneDrive](../protocols/onedrive.md) & [Microsoft SharePoint](../protocols/sharepoint.md) protocols.
 
-`````{tabs}
-````{group-tab} Cyberduck
+::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *File → Share…*. to create an [shared link](../protocols/onedrive.md) for a file or folder.
 
-````
-````{group-tab} Mountain Duck
+:::
+:::{group-tab} Mountain Duck
 
 Choose *Share…* from the [context menu](../mountainduck/interface.md#share) to create a [shared link](../protocols/onedrive.md) for a file or folder.
 
-````
-`````
+:::
+::::
 
 ### Dropbox
 
 For connections to [Dropbox](../protocols/dropbox.md).
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *File → Share…* to share an [URL](../protocols/dropbox.md#share--request-files) to provide access to a document in your Dropbox. Optionally set a password required to download the file. Choose *Skip* to create a public URL with no password protection.
 
-```{image} ../cyberduck/_images/Passphrase_Prompt_Dropbox_Share.png
+:::{image} ../cyberduck/_images/Passphrase_Prompt_Dropbox_Share.png
 :alt: Passphrase Prompt Dropbox Share
 :width: 400px
-```
+:::
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Choose *Share…* from the [context menu](../mountainduck/interface.md#share) to share an [URL](../protocols/dropbox.md#share--request-files) to provide access to a document in your Dropbox. Optionally set a password required to download the file. Choose *Skip* to create a public URL with no password protection.
 
-```{image} ../cyberduck/_images/Passphrase_Prompt_Dropbox_Share.png
+:::{image} ../cyberduck/_images/Passphrase_Prompt_Dropbox_Share.png
 :alt: Passphrase Prompt Dropbox Share
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### Google Drive
 
 For connections to [Google Drive](../protocols/googledrive.md).
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Choose *File → Share…*. to share the web link to open download or open the file in Google Docs. This will set the permission of the file to `reader/anyone`.
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Choose *Share…* from the [context menu](../mountainduck/interface.md#share) to share the web link to open download or open the file in Google Docs. This will set the permission of the file to `reader/anyone`.
 
-```{image} ../cyberduck/_images/Share_File_Google_Drive_.png
+:::{image} ../cyberduck/_images/Share_File_Google_Drive_.png
 :alt: Share File Google Drive
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### NextCloud & ownCloud
 
 For connections to [NextCloud & ownCloud](../protocols/webdav/nextcloud.md) servers.
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Create public shares for people who are not Nextcloud users. Optionally set a password required to download the file. Choose *Skip* to create a public URL with no password protection. 
 
 - Choose *File → Share…* for download shares. You can create a public link by choosing `Everyone` or a private link for a specific user by selecting the users email. The user will be notified about the shared file by email.
 - Choose *File → Request files…* for upload shares. 
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Create public shares for people who are not Nextcloud users. Optionally set a password required to download the file. Choose *Skip* to create a public share with no password protection. 
 
 Choose *Share…* for download shares or *Request files…* for upload shares from the [context menu](../mountainduck/interface.md#share).
 
-```{image} ../cyberduck/_images/Download_Share_Context_Menu.png
+:::{image} ../cyberduck/_images/Download_Share_Context_Menu.png
 :alt: Download Share Context Menu
 :width: 300px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### Box
 
 For connections to [Box](../protocols/box.md).
 
-`````{tabs}
-````{group-tab} Cyberduck
+:::::{tabs}
+::::{group-tab} Cyberduck
 
 Create download shares by choosing *File → Share…*. Optionally set a password required to download the file or folder. Choose *Skip* to create a public URL without password protection. A Box account is not required to open the URL.
 
-````
-````{group-tab} Mountain Duck
+::::
+::::{group-tab} Mountain Duck
 
 Create download shares for files and folders by choosing *Share…* from the [context menu](../mountainduck/interface.md#share). Optionally set a password required to download the file or folder. Choose *Skip* to create a public URL without password protection. A Box account is not required to open the URL.
 
-```{image} ../cyberduck/_images/Download_Share_Box.png
+:::{image} ../cyberduck/_images/Download_Share_Box.png
 :alt: Download Share Box
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ### FTP, SFTP & WebDAV
 
 If you connect to a web root using ### [FTP](../protocols/ftp.md), [SFTP](../protocols/sftp/index.md) or [WebDAV](../protocols/webdav/index.md), refer to [HTTP URL](../cyberduck/bookmarks.md#http-url) on how to configure your bookmark to allow copying a HTTP URL for a selected file. With a valid configuration, you can open the corresponding HTTP URL of a file selected with your default web browser or copy the URL to the clipboard. To manage permissions, refer to [UNIX Permissions (FTP/SFTP)](info.md#unix-permissions).
 
-```{note}
+:::{note}
 You must use [Cyberduck](https://cyberduck.io) to edit the Web URL in a bookmark. The Web URL will replace your server address in URLs available in *Copy URL* .
-```
+:::

--- a/cyberduck/spotlight.md
+++ b/cyberduck/spotlight.md
@@ -7,9 +7,9 @@ Cyberduck includes a custom *Spotlight Importer Plugin* to search the contents o
 
 ## Using the Spotlight Menu
 
-```{note}
+:::{note}
 The *Spotlight Menu* does return no results for recently connected servers in Cyberduck because it excludes indexed files located in `~/Library/Application Support/Cyberduck/History`. This is also an issue for Adium.
-```
+:::
 
 As a workaround, you have to export all bookmarks to another location such as your *Documents* folder. Select all bookmarks *(⌘A)* in the bookmark list and drag these somewhere in your *Documents* folder in the Finder. You can then search bookmarks in the *Spotlight Menu* by nickname and hostname. Additionally, to display all bookmarks as a result search for `kind:"Cyberduck Bookmark"`.
 
@@ -24,16 +24,16 @@ Follow these steps:
 - Add another criteria using the `+` button.
 - Select to include system files in the custom search by choosing *Other...* in the criteria drop-down menu.
 
-```{image} _images/system_files_criteria.png
+:::{image} _images/system_files_criteria.png
 :alt: System Files Criteria
 :width: 600px
-```
+:::
 
 - Choose *System files* as search criteria and choose *are included* as the value.
 
 When configured, the saved search looks the following:
 
-```{image} _images/Cyberduck_saved_search.png
+:::{image} _images/Cyberduck_saved_search.png
 :alt: Cyberduck Saved Search
 :width: 800px
-```
+:::

--- a/cyberduck/support.md
+++ b/cyberduck/support.md
@@ -7,33 +7,33 @@ Support
 
 If you have a feature request please make sure to include a detailed and comprehensible description of the requested feature in [the ticket](https://github.com/iterate-ch/cyberduck/issues/new/choose). Make sure to check if someone already requested a similar feature.
 
-```{warning}
+:::{warning}
 For issues with your remote storage user account credentials, please instead write to your hosting service provider. 
-```
+:::
 
 ### Bug Reports
 
 [Open a new ticket](https://github.com/iterate-ch/cyberduck/issues/new/choose) with a description of what you have done and what went wrong. Make sure to look or search for existing issues first. If you have trouble connecting to a server or your login credentials are not valid, try to resolve the issue with the assistance of your hosting service provider.
 
-```{note}
+:::{note}
 Discuss features and issues you are having in [GitHub Discussions](https://github.com/iterate-ch/cyberduck/discussions). For issues with the registration key, please send an email to [support@cyberduck.io](mailto:support@cyberduck.io).
-```
+:::
 
-```{warning}
+:::{warning}
 Please be aware that you are possibly using our software at no charge if you have not purchased a registration key. Thus the support provided here is best effort only.
-```
+:::
 
 ## Logging Output
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 Log output can be found in the `cyberduck.log` file in`~/Library/Logs/Cyberduck`. Select _Show_ in _Cyberduck → Preferences → Connection_ to reveal the log file. Alternatively, you can find `cyberduck.log` in *Console.app* (Open from `/Applications/Utilities`) under `Reports → Log Reports → cyberduck.log`.
 
-```{image} _images/Console.app.png
+:::{image} _images/Console.app.png
 :alt: Console.app
 :width: 600px  
-```
+:::
 
 ### Transcript
 
@@ -41,17 +41,17 @@ You can access the transcript which will log protocol request and responses from
 
 `log stream --predicate '(process == "Cyberduck") && (category == "transcript")' --level info`
 
-```{note}
+:::{note}
 The transcript will be written in the *Terminal.app* window. Make sure to keep the window open after executing the command.
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 Log output can be found in the `cyberduck.log` file in `%AppData%\cyberduck`. Select _Show_ in _Cyberduck → Preferences → Connection_ to reveal the log file named *cyberduck.log*.
 
-````
-`````
+::::
+:::::
 
 ### Debug Log
 
@@ -61,30 +61,30 @@ To enable verbose log output select _Enable debug log_ in _Cyberduck → Prefere
 
 Inside the application support folder, the application saves files needed for their operations e.g. settings, log data, history files, etc.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 You can reach the application support folder by choosing `Go → Go to folder` within the *Finder* menu and paste the path `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/` into the window.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 You can reach the application support folder by navigating to `%AppData%\Cyberduck` by copying the path into the address bar of the Explorer and press *Return* afterward.
 
-````
-`````
+:::
+::::
 
 ### Crash Reports
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Crash reports are saved to `~/Library/Logs/DiagnosticReports/Cyberduck_*.crash`. On macOS 12 or later crash reports are saved to `~/Library/Logs/DiagnosticReports/Cyberduck_*.ips`.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Crash reports are saved to `%AppData%\cyberduck\CrashReporter`.
 
-````
-`````
+:::
+::::

--- a/cyberduck/support.md
+++ b/cyberduck/support.md
@@ -35,7 +35,7 @@ Log output can be found in the `cyberduck.log` file in`~/Library/Logs/Cyberduck`
 :width: 600px  
 :::
 
-### Transcript
+**Transcript**
 
 You can access the transcript which will log protocol request and responses from the command line particularly useful for protocols using HTTP. Open a *Terminal.app* window and enter 
 

--- a/cyberduck/sync.md
+++ b/cyberduck/sync.md
@@ -5,9 +5,9 @@ Synchronize Folders
 
 Files can be synchronized by selecting the directory to synchronize in the browser and select *File → Synchronize*. You will be prompted to select the directory on your computer to synchronize the files with.
 
-```{important}
+:::{important}
 The options in *Preferences → Transfers → Timestamps* must be enabled.
-```
+:::
 
 The criteria to download or upload a file are given by
 
@@ -16,10 +16,10 @@ The criteria to download or upload a file are given by
 
 You will be prompted to confirm the actions and if missing files should only be downloaded, uploaded, or mirrored.
 
-```{image} _images/Synchronize_Folders.png
+:::{image} _images/Synchronize_Folders.png
 :alt: Synchronize Folders
 :width: 700px
-```
+:::
 
 - **Checkbox:** Toggle to include or exclude files or directories from the transfer.
 - **Down Arrow:** The file is downloaded from the server replacing the local file if included.

--- a/cyberduck/transfer.md
+++ b/cyberduck/transfer.md
@@ -1,10 +1,10 @@
 File Transfers
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 The *Transfers* window lists pending and completed transfers. The list is retained when the application is closed and can be retrieved after restarting so that the transfer can be restarted at a later time.
 
@@ -17,14 +17,14 @@ The *Transfers* window lists pending and completed transfers. The list is retain
 
 *Resume* will try to finish a transfer previously interrupted.
 
-```{note}
+:::{note}
 Some servers may not support resumable transfers and the file will be reloaded instead.
-```
+:::
 
-```{image} _images/Transfers.png
+:::{image} _images/Transfers.png
 :alt: Transfers
 :width: 700px
-```
+:::
 
 ## Interrupt
 
@@ -34,11 +34,11 @@ You can interrupt a transfer using the *Stop* toolbar button.
 
 Use the *Open* toolbar button to open a downloaded file or folder.
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 A warning might be displayed before opening the file. See the [download quarantine](download.md#quarantine).
-```
+:::
 
 ## Show Downloaded Files
 
@@ -46,33 +46,34 @@ Using the *Show in Finder* or *Show* toolbar button, files are shown in *Finder.
 
 ## Progress
 
-````{admonition} Windows only
+::::{admonition} Windows only
 :class: tip
 
 If the *Transfers* window is closed, progress is also visible in the application icon in the Taskbar.
 
-```{image} _images/Transfer_Progress.png
+:::{image} _images/Transfer_Progress.png
 :alt: Transfer Progress
 :width: 100px
-```
-````
+:::
+
+::::
 
 ## Bandwidth
 
 Limit the maximum bandwidth that is allowed for transfers. Useful when you don't want transfers to take all the bandwidth available on your internet connection that would slow down other connections. 
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Select *Bandwidth* from the toolbar in the transfer window and set the maximum bandwidth allowed by the selected transfer from the drop-down window. The default setting is configurable in the [Preferences](preferences.md).
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Use the drop-down menu in the lower right of the transfer window to set the maximum bandwidth allowed by the selected transfer. The default setting is configurable in the [Preferences](preferences.md).
 
-````
-`````
+:::
+::::
 
 ## Connections
 
@@ -82,19 +83,19 @@ You can choose to use single or multiple connections for file transfers. Choose 
 **Open single connection:** Use a single connection additionally to the browser connection to transfer files from a transfer sequentially.<br/>
 **Open multiple connections:** Use multiple connections to transfer files from a transfer concurrently.
 
-```{image} _images/Transfer_Options.png
+:::{image} _images/Transfer_Options.png
 :alt: Transfer Options
 :width: 300px
-```
+:::
 
 ### Limit Number of Parallel Connections
 
 The maximum number of connections for transfers using multiple connections can be limited using the toggle in the lower right of the *transfer window* on Windows or the *toolbar dropdown* on macOS.
 
-```{image} _images/Limit_Connections.png
+:::{image} _images/Limit_Connections.png
 :alt: Limit Connections
 :width: 500px
-```
+:::
 
 The setting limits
 * The number of parallel transfers in progress the _Transfers_ window. Transfers awaiting will show _Maximum allowed connections exceeded. Waiting…_.
@@ -105,10 +106,10 @@ The setting limits
 
 A prompt is displayed if files already exist at the target location (on your local hard disk for downloads or on the server for uploads) and you have selected *Prompt* in *Transfers → General → Downloads/Uploads → Existing Files*. The prompt allows choosing the action for existing files. You can exclude selected files and folders from the transfer action by unchecking the checkbox next to it. If the checkbox is not selected, these files will be skipped.
 
-```{image} _images/Overwrite_Prompt.png
+:::{image} _images/Overwrite_Prompt.png
 :alt: Overwrite Prompt
 :width: 700px
-```
+:::
 
 **Exclamation mark triangle:** File size is zero or differs from the existing file.
 
@@ -116,10 +117,10 @@ A prompt is displayed if files already exist at the target location (on your loc
 
 Replace any existing file restarting the transfer from scratch. Existing files are moved to the trash.
 
-```{image} _images/Overwrite_Options.png
+:::{image} _images/Overwrite_Options.png
 :alt: Overwrite Options
 :width: 600px
-```
+:::
 
 ### Compare
 
@@ -210,17 +211,17 @@ Choose between a default permission mask to apply to downloaded files or to appl
 
 Adjust the permission mask of uploaded files or leave it to the default mask chosen by the server. The setting for permissions apply when connected to a UNIX host using [FTP](../protocols/ftp.md) or [SFTP](../protocols/sftp/index.md). When connected to [S3](../protocols/s3/index.md) and [Azure](../protocols/azure.md) this will update the access control list (ACL).
 
-```{note}
+:::{note}
 Enabling change of permissions slows down the transfer rate when uploading many files with [FTP](../protocols/ftp.md).
-```
+:::
 
 ### Transfers → Timestamps
 
 Preserve modification date when uploading or downloading files. For [synchronization](sync.md) to work, these options must be enabled.
 
-```{note}
+:::{note}
 Enabling change of modification date slows down the transfer rate when uploading many files with [FTP](../protocols/ftp.md).
-```
+:::
 
 ## Hidden Preferences
 
@@ -228,18 +229,24 @@ Enabling change of modification date slows down the transfer rate when uploading
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). Edit the available options (in bytes).
 
-    defaults write ch.sudo.cyberduck queue.bandwidth.options 102400,1073741824
+```
+defaults write ch.sudo.cyberduck queue.bandwidth.options 102400,1073741824
+```
 
 ### Badge Dock Icon
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). Add a badge with the number of currently running transfers to the dock icon.
 
-    defaults write ch.sudo.cyberduck queue.dock.badge true
+```
+defaults write ch.sudo.cyberduck queue.dock.badge true
+```
 
 ### Prioritize Files in Transfers
 
 A [hidden configuration option](preferences.md#hidden-configuration-options). Use `queue.upload.priority.regex` and `queue.download.priority.regex` to determine order of files transferred in folders. For example:
 
-    defaults write ch.sudo.cyberduck queue.upload.priority.regex ".*\.html"
+```
+defaults write ch.sudo.cyberduck queue.upload.priority.regex ".*\.html"
+```
 
 will prioritize files ending with `.html` and transfer before any other files in a folder.

--- a/cyberduck/upload.md
+++ b/cyberduck/upload.md
@@ -11,10 +11,10 @@ Select *File → Upload...* to select files to upload.
 
 There is a toolbar button available that you can add using *View → Customize Toolbar...*.
 
-```{image} _images/Toolbar_Upload.png
+:::{image} _images/Toolbar_Upload.png
 :alt: Toolbar Upload
 :width: 300px
-```
+:::
 
 ## Using Drag & Drop
 
@@ -32,54 +32,55 @@ Upload files without first opening a connection to a server by dropping the file
 
 You can browse your local hard disk within Cyberduck and drag files to the remote browser opened in another window or tab.
 
-```{image} _images/Connection_Popup.png
+:::{image} _images/Connection_Popup.png
 :alt: Connection Popup
 :width: 400px
-```
+:::
 
 ### Drag to the Dock
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 Drag files to the application icon in the `Dock` which will upload to the frontmost browser. A prompt is displayed to choose the bookmark to upload the files to (with the bookmark of the current browser selected by default if any).
-```
+:::
 
-```{image} _images/Bookmark_Upload_Selection.png
+:::{image} _images/Bookmark_Upload_Selection.png
 :alt: Bookmark Upload Selection
 :width: 400px
-```
+:::
 
 ## Using Copy & Paste
 
 Copy a file in the *Finder.app* or *Explorer* with *Edit → Copy (macOS `⌘C` Windows `Ctrl+C`)* and paste it to a browser window in Cyberduck to upload with *Edit → Paste (macOS `⌘V` Windows `Ctrl+V`)*.
 
-```{image} _images/Paste_Files.png
+:::{image} _images/Paste_Files.png
 :alt: Paste Files
 :width: 300px
-```
+:::
 
 ## The Service Menu
 
-````{admonition} macOS only
+::::{admonition} macOS only
 :class: tip
 
 When selecting files in the *Finder* or another application with references to files and folders, choose the item *Services → Upload* (with the Cyberduck icon) in the application menu to launch Cyberduck and upload the items selected to the bookmark you choose. This action is also available in the context menu (right-click on files or folders) in the *Finder*.
 
-```{image} _images/Services_Upload.png
+:::{image} _images/Services_Upload.png
 :alt: Services Upload
 :width: 300px
-```
-````
+:::
 
-```{note}
+::::
+
+:::{note}
 Make sure in *System Preferences → Keyboard → Keyboard Shortcuts → Services → Files and Folders* the item *Upload with Cyberduck* is selected.
-```
+:::
 
-```{image} _images/Upload_from_Finder.png
+:::{image} _images/Upload_from_Finder.png
 :alt: Upload from Finder
 :width: 600px
-```
+:::
 
 ## Preferences
 
@@ -87,6 +88,8 @@ Make sure in *System Preferences → Keyboard → Keyboard Shortcuts → Service
 
 An option to upload with a temporary name and rename the file after the transfer is complete. An upload that is not complete, will not be renamed. This is useful for uploading to watch folders, that should only pick up a file once the upload is complete. To specify a different temporary filename pattern, use the [hidden configuration option](preferences.md#hidden-configuration-options)
 
-    defaults write ch.sudo.cyberduck queue.upload.file.temporary.format "'{0}-{1}'"
+```
+defaults write ch.sudo.cyberduck queue.upload.file.temporary.format "'{0}-{1}'"
+```
 
 where `{0}` is the original filename and `{1}` is a random UUID. The default setting uses a temporary filename of `filename-uuid`.

--- a/index.md
+++ b/index.md
@@ -1,42 +1,42 @@
 Cyberduck & Mountain Duck Help
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 :caption: Cyberduck
 
 cyberduck/index
-```
+:::
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 :caption: Cyberduck CLI
 cli/index
-```
+:::
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 :caption: Mountain Duck
 mountainduck/index
-```
+:::
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 :caption: Supported Protocols
 protocols/index
 protocols/profiles/index
-```
+:::
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 :caption: Cryptomator
 cryptomator/index
-```
+:::
 
 ## Support
 

--- a/mountainduck/connect/index.md
+++ b/mountainduck/connect/index.md
@@ -1,23 +1,23 @@
 Connect mode
 ===
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 sync
 online
-```
+:::
 
 When connecting to a server, you can choose between *[Online](online.md)* and *[Smart Synchronization](sync.md)* connect
 mode.
 
-```{admonition} Online
+:::{admonition} Online
 In _Online_ connect mode, changes to a file are immediately uploaded and in sync when an application has finished saving a file.
-```
+:::
 
-```{admonition} Smart Synchronization
+:::{admonition} Smart Synchronization
 In _Smart Synchronization_ connect mode, files are copied to a local cache for faster access prior synchronization with the server in the background.
-```
+:::
 
 ## Feature Comparison
 
@@ -33,6 +33,7 @@ In _Smart Synchronization_ connect mode, files are copied to a local cache for f
 | **[Share Files](../share.md)**           | ✔                                                                     | ✔                                                                             |
 
 ## Quota Support
+
 Mountain Duck displays the overall quota present on the server as available disk space on the mounted volume.
 
 | Protocol                 | Support |
@@ -57,14 +58,15 @@ Mountain Duck displays the overall quota present on the server as available disk
 | [Windows Azure ](../../protocols/azure.md)         | ❌ |
 | [OpenStack Object Storage](../../protocols/openstack/index.md)  | ✅ |
 
-```{admonition} Limited Support
+:::{admonition} Limited Support
 :class: attention
+
 - **[Microsoft OneDrive](../../protocols/onedrive.md#quota)**: Quota is only supported when setting the *Path* in the bookmark configuration to a folder different from `/`.
 - **[Microsoft SharePoint](../../protocols/sharepoint.md#quota)**: Quota is only supported when setting the *Path* in the bookmark configuration to a *Drives* folder in a SharePoint site folder.
-```
+:::
 
 Some protocols do not report the available quota. Finder and Windows Explorer will show exabyte values in *Online* connect mode and the available space within the synchronization cache location on your local disk in *Smart Synchronization* connect mode for the affected protocols.
 
-```{note}
+:::{note}
 Quota support can be [disabled](../../protocols/sftp/index.md#free-space-calculation-is-incorrect) for all protocols.
-```
+:::

--- a/mountainduck/connect/online.md
+++ b/mountainduck/connect/online.md
@@ -1,42 +1,43 @@
 Online
 ===
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
-```
+:::
 
 > In _Online_ connect mode, changes to a file are immediately uploaded and in sync when an application has finished saving a file. Files are accessed on demand from the remote when opened and do not take up any local disk space. Files are not synchronized on local disk but only saved temporarily when required and deleted at the latest when the bookmark is disconnected. 
 
-```{tip}
+:::{tip}
 You can only access volumes in _Online_ connect mode when a connection is possible to the server or cloud storage.
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 1
 :local:
-```
+:::
 
 ## Status of Files
 
 Files and folders on a mounted volume have a status icon overlay in _File Explorer_ (Windows) and _Finder_ (macOS).
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
+
 Please make sure to enable the Mountain Duck [Integration](../installation/index.md) in *System Preferences → Extensions → Finder* on macOS. For macOS Ventura and later, the setting can be found in *System Settings → Privacy & Security → Extensions → Added Extensions*.
-```
+:::
 
 ### ![](../_images/overlay_infinite.png) Online Only
+
 The file can only be opened when a connection to the server or cloud storage can be made. The file does not take any space on your computer. The file is downloaded on demand when you open it.
 
 ### ![](../_images/overlay_ignored.png) Ignored
-The file or folder is only saved in a local [temporary](../issues/index.md#temporary-files) location and not uploaded. This includes files matching a [temporary filename pattern](../issues/index.md#filenames), empty files and new folders.
 
+The file or folder is only saved in a local [temporary](../issues/index.md#temporary-files) location and not uploaded. This includes files matching a [temporary filename pattern](../issues/index.md#filenames), empty files and new folders.
 
 ## Transfer Progress
 
 While transferring files and folders, a transfer [progress](../interface.md#copying-files) window shows in _Finder.app_ or _Windows Explorer_. When completed, the file(s) have been uploaded to the server.
-
 
 ## Notifications
 
@@ -45,7 +46,6 @@ Notifications can be posted for the following events:
 - **Filesystem unmounted**. The volume has been disconnected.
 - **Download complete**. File download completed in the background.
 - **Upload complete**. File upload completed in the background.
-
 
 You can adjust which notifications you want to receive in [*Preferences → Notifications*](../preferences.md#notifications).
 

--- a/mountainduck/connect/sync.md
+++ b/mountainduck/connect/sync.md
@@ -201,23 +201,23 @@ The *Recent Files* area shows the last 20 changes to files by you or on the serv
 :width: 600px
 :::
 
-#### ![Delete](../_images/delete.png) Delete
+### ![Delete](../_images/delete.png) Delete
 
 A file or folder has been deleted either *by you* or *on the server*
 
-#### ![Create](../_images/plus.png) Create
+### ![Create](../_images/plus.png) Create
 
 A file or folder was created or updated *on the server*.
 
-#### ![Upload](../_images/transfer_upload.png) Upload
+### ![Upload](../_images/transfer_upload.png) Upload
 
 A file or folder was added or changed *by you* and uploaded to the server.
 
-#### ![Download](../_images/transfer_download.png) Download
+### ![Download](../_images/transfer_download.png) Download
 
 A file is downloaded to the local cache to be available for offline use. This state also occurs if a file that is marked as *Keep offline* has updated on the server.
 
-#### ![Error](../_images/alert.png) Error
+### ![Error](../_images/alert.png) Error
 
 The sync operation failed for the file. A file may show up with an error state indicating an issue while synchronizing. Further details are available through the [sync option menu item](../interface.md#context-menu-in-finder-and-windows-file-explorer).
 

--- a/mountainduck/connect/sync.md
+++ b/mountainduck/connect/sync.md
@@ -1,56 +1,63 @@
 Smart Synchronization
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
-```
+:::
 
-```{image} ../_images/Disk_Syncing.png
+:::{image} ../_images/Disk_Syncing.png
 :alt: Disk Syncing
 :width: 200px
-```
+:::
+
 > In _Smart Synchronization_ connect mode, files are copied to a local cache for faster access prior synchronization with the server in the background. Directories can be browsed when offline and files opened are made available for later offline access. You can also choose to make explicitly all or only selected files and folders available for offline use. Changes to files are saved in a local cache first and uploaded in the background as soon as a connection is available.
 
-```{tip}
+:::{tip}
 You can access volumes in _Smart Synchronization_ connect mode without being always connected the server or cloud storage.
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 1
 :local:
-```
+:::
 
 ## Status of Files
 
 Files and folders on a mounted volume have a status icon overlay in _File Explorer_ (Windows) and _Finder_ (macOS).
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
+
 Please make sure to enable the Mountain Duck [Integration](../installation/index.md) in *System Preferences → Extensions → Finder* on macOS. For macOS Ventura and later, the setting can be found in *System Settings → Privacy & Security → Extensions → Added Extensions*.
-```
+:::
 
 ### ![](../_images/overlay_uptodate.png) Up to Date
+
 The file or the contents of a directory has been opened and downloaded to your computer and therefore currently synced with the server or cloud storage. The file takes disk space on your computer and can always be opened even when no connection to the server or cloud storage is possible. New files in a directory on the remote server will appear as *Online Only* and are not downloaded automatically. Files copied to a volume are kept cached by default.
 
-```{note}
+:::{note}
 Files can be purged automatically from the cache when not accessed or the cache size limit is exceeded. Refer to [Cache Limitations](../preferences.md#cache-limitations).
-```
+:::
 
 ### ![](../_images/overlay_infinite.png) Online Only
+
 The file can only be opened when a connection to the server or cloud storage can be made. The file does not take any space on your computer. The file is downloaded on demand when you open it.
 
 ### ![](../_images/overlay_sync.png) In Sync
+
 The file or folder is selected to be synced with the server or cloud storage to always keep offline. The file takes disk space on your computer and can always be opened even when no connection to the server or cloud storage is possible. New files in a directory on the remote server will be downloaded automatically.
 
-```{tip}
+:::{tip}
 Files explicitly selected to keep offline are **not** automatically purged. Refer to [Cache Limitations](../preferences.md#cache-limitations).
-```
+:::
 
 ### ![](../_images/overlay_syncing.png) Sync in Progress
+
 The file or folder is currently syncing with the server or cloud storage. Check the menu with the sync status for current download or upload progress.
 
 ### ![](../_images/overlay_error.png) Sync Error
+
 Files that failed to sync after changes. You are missing permission to write to the file or another problem occurred. Please contact your web hosting service provider for assistance. To resolve the error, move the file to your local disk, and reload the directory. Refer to [Sync Conflicts](sync.md#sync-conflicts) for possible error scenarios. You can try to repeat the failed transfer by selecting *Mountain Duck → Retry* in the [context menu](sync.md#context-menu-options). If a sync error cannot be solved using *Mountain Duck → Retry* because the server does not allow the operation (i.e. due to a permission issue), you can resolve the error state on the file or folder by
 
 - Move the file or folder to another location on the volume
@@ -58,17 +65,20 @@ Files that failed to sync after changes. You are missing permission to write to 
 - To upload files to a target directory no longer existing on the server, you have to move the files to a location found on the server.
 
 ### ![](../_images/overlay-pause.png) Sync Paused
+
 The file or folder is pending syncing with the server but synchronization has been [paused](#pause-sync).
 
 ### ![](../_images/overlay_ignored.png) Ignored
+
 The file or folder is only saved in local cache and not synced. New _Folders_, empty files and files matching [excluded filename patterns](../issues/index.md#filenames) are not uploaded. Folders are uploaded after being renamed.
 
 ## Notifications
 
-```{image} ../_images/File_Updated_Notification.png
+:::{image} ../_images/File_Updated_Notification.png
 :alt: File Updated Notification
 :width: 500px
-```
+:::
+
 Notifications can be posted for the following events:
 - **Filesystem mounted**. The volume is now connected.
 - **Filesystem unmounted**. The volume has been disconnected.
@@ -89,31 +99,31 @@ You can adjust which notifications you want to receive in [*Preferences → Noti
 
 To reach the context menu right-click on a file or folder in _File Explorer_ (Windows) or _Finder_ (macOS). Refer to [Finder Extension & Windows File Explorer Extension](../interface.md#context-menu-in-finder-and-windows-file-explorer).
 
-```{image} ../_images/Mountain_Duck_Screenshot_Finder_Dark.png
+:::{image} ../_images/Mountain_Duck_Screenshot_Finder_Dark.png
 :alt: Mountain Duck Finder Dark
 :width: 800px
-```
+:::
 
 ### Keep Offline
 
 Choose *Mountain Duck → Keep Offline on Local Disk* to make files and folders available even offline with no network connectivity. The status of the file will change to *In Sync*. The action is recursive for all contained files when a folder is selected and applies to new files found on the remote storage.
 
-```{image} ../_images/Sync_Context_Menu_macOS.png
+:::{image} ../_images/Sync_Context_Menu_macOS.png
 :alt: Sync Context Menu (macOS)
 :width: 500px
-```
+:::
 
-```{note}
+:::{note}
 As long as the volume is mounted, files marked _Up to Date_ or _In Sync_ with a green checkmark remain accessible even if the network connection drops. Changes are synchronized in the background when the server is reachable again. 
-```
+:::
 
 ### Delete on Local Disk
 
 Choose *Mountain Duck → Delete on Local Disk* to delete the offline copy. The status of the file will change to *Online Only*. The action is recursive for all contained files when a folder is selected and allows you to quickly free up space used in the cache on your local disk.
 
-```{note}
+:::{note}
 Files will get cached again regardless this setting if accessed again later (e.g. Finder and Windows Explorer thumbnail preview and media file metadata retrieval).
-```
+:::
 
 <video width="800" height="450" controls>
 	<source src="../../../_static/videos/mountainduck/keepoffline.mp4" type="video/mp4" />
@@ -139,78 +149,92 @@ While transferring files and folders, a transfer [progress](../interface.md#copy
 
 Changes to files are uploaded in the background as soon as a connection is available. Progress is reported by animating the status bar icon and a menu item titled *Sync in Progress*.
 
-```{image} ../_images/Icon_Sync_in_Progress.gif
+:::{image} ../_images/Icon_Sync_in_Progress.gif
 :alt: Sync in Progress
 :width: 600px
-```
+:::
+
 Detailed status for current transfers is available in the *Sync* submenu. The sync progress shows the files that currently get synchronized and pending changes after the current transfer.
 
-```{image} ../_images/Menu_Sync_in_Progress.png
+:::{image} ../_images/Menu_Sync_in_Progress.png
 :alt: Sync Progress
 :width: 800px
-```
+:::
 
 Shown for the current transfers are transfer rate, remaining data, and already transferred data. If Mountain Duck synchronizes files in a badge, the file state might differ from the state within the file browser. The sync progress display is limited to 5 entries.
 
-
 ### Pause Sync
+
 You can manually pause background syncing by selecting *Pause Sync* in the submenu for the sync status. The paused sync status is indicated with a greyed-out icon in the tray (Windows) or status bar (macOS).
 
-```{image} ../_images/Sync_Paused_macOS.png
+:::{image} ../_images/Sync_Paused_macOS.png
 :alt: Sync Paused (macOS)
 :width: 500px
-```
+:::
+
 Syncing is also paused automatically when your network connection to the server is interrupted but resumed automatically when a connection is restored.
 
-```{warning}
+:::{warning}
 When synchronization is paused by selecting _Pause Sync_ in the menu or caused by a connectivity problem, no changes from the server will be detected. Additionally, files marked as [Online Only](#online-only) cannot be opened: The application attempting to open the file will show an error message and a *Access Denied* notification is shown.
-```
+:::
 
 ### Cancel Upload in Progress
+
 To abort the upload of a file, follow these steps:
 1. Choose *Pause Synchronization* in the Mountain Duck _Synchronization_ menu.
 2. Delete the file
 3. *Resume Synchronization* in the dropdown menu.
 
 ### Cancel Download in Progress
+
 To abort the download of a file, follow these steps:
 1. Choose *Pause Synchronization* in the Mountain Duck _Synchronization_ menu.
 2. Select *Delete on local Disk* within the Mountain Duck [context menu](../interface.md#context-menu-in-finder-and-windows-file-explorer).
 3. *Resume Synchronization* in the dropdown menu.
 
 ## Recent Files
+
 The *Recent Files* area shows the last 20 changes to files by you or on the server:
-```{image} ../_images/Recent_Files.png
+
+:::{image} ../_images/Recent_Files.png
 :alt: Recent Files
 :width: 600px
-```
+:::
 
 #### ![Delete](../_images/delete.png) Delete
+
 A file or folder has been deleted either *by you* or *on the server*
 
 #### ![Create](../_images/plus.png) Create
+
 A file or folder was created or updated *on the server*.
 
 #### ![Upload](../_images/transfer_upload.png) Upload
+
 A file or folder was added or changed *by you* and uploaded to the server.
 
 #### ![Download](../_images/transfer_download.png) Download
+
 A file is downloaded to the local cache to be available for offline use. This state also occurs if a file that is marked as *Keep offline* has updated on the server.
 
 #### ![Error](../_images/alert.png) Error
+
 The sync operation failed for the file. A file may show up with an error state indicating an issue while synchronizing. Further details are available through the [sync option menu item](../interface.md#context-menu-in-finder-and-windows-file-explorer).
 
 ### Application Display
 
-```{admonition} Windows Only
+:::{admonition} Windows Only
 :class: tip
 
 The application that was used for editing the file is displayed within the *Recent Files* area.
-```
+:::
+
 ### Reveal File
+
 Selecting an item in the *Recent Files* section reveals the file in the _Finder_ (macOS) of _File Explorer_ (Windows).
 
 ### Clear Menu
+
 Clear out all entries of the list by clicking on the *Clear Menu* button at the bottom of the menu.
 
 ## Troubleshooting

--- a/mountainduck/index.md
+++ b/mountainduck/index.md
@@ -1,7 +1,7 @@
 Mountain Duck
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 installation/index
@@ -14,7 +14,7 @@ versions
 preferences
 issues/index
 support
-```
+:::
 
 Cyberduck for mounting volumes in the file explorer is available for Mac & Windows.
 

--- a/mountainduck/info.md
+++ b/mountainduck/info.md
@@ -1,2 +1,2 @@
-```{include} ../cyberduck/info.md
-```
+:::{include} ../cyberduck/info.md
+:::

--- a/mountainduck/installation/index.md
+++ b/mountainduck/installation/index.md
@@ -1,22 +1,22 @@
 Installation
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 
 licensing
-```
+:::
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 **Download**<br/>
 Move the unzipped application bundle *Mountain Duck.app* from the Downloads to the `/Applications` folder on your computer.
 
-```{note}
+:::{note}
 No admin privileges for installation is required.
-```
+:::
 
 **Mac App Store**<br/>
 Mountain Duck is installed through the Mac App Store in `/Applications`. You can always reinstall Mountain Duck on any Mac you own from the Mac App Store in *→ App Store... → Purchased*.
@@ -32,15 +32,14 @@ Enable the Mountain Duck Finder Extension in *System Preferences → Extensions 
 - **Context menu items** for files selectec on a mounted volume with options to *Reload* the folder listing and copy & open URLs of files
 - **Badges** on file icons to display sync status when *Smart Synchronization* is enabled for the bookmark
 
-```{note}
+:::{note}
 For **macOS Ventura and later**, the setting can be found in *System Settings → Privacy & Security → Extensions → Added Extensions*.
-```
+:::
 
 ![Mountain Duck Finder Integration](_images/Mountain_Duck_Finder_Integration.png) 
 
-````
-
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 **Installer**<br/>
 [Download](https://mountainduck.io/changelog/) the *Mountain Duck Installer.exe* and install Mountain Duck with administrator privilege.
@@ -50,54 +49,54 @@ For **macOS Ventura and later**, the setting can be found in *System Settings �
 **MSI**<br/>
 [Download](https://mountainduck.io/changelog/) MSI Installer for corporate environments. Requires prior installation of *Microsoft .NET Framework 4.7.2*.
 
-```{note}
+:::{note}
 Using the MSI Installer, you'll have to install the *MSI Package Shell Extension for 32bit applications* **and** *MSI Package Shell Extension for 64bit applications* separately. Both packages are needed to enable the explorer extension.
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ## System Requirements
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 - Mountain Duck 3.3.5 or later requires *macOS 10.12* or later
 - Mountain Duck 3.0.1 or later requires *macOS 10.11* or later
-````
 
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 Requires *.NET Framework 4.7.2.* If the {download}`.Net Framework installation<https://dotnet.microsoft.com/download/dotnet-framework/net472>` fails, download it manually.
 
 - Mountain Duck 4.13.0 or later requires *Windows 10 (14393) or Windows Server 2016* or later on 64 Bit.
 - Mountain Duck 3.2.0 or later requires *Windows 7, Windows 8.1, Windows 10 (14393)* or later on 64Bit.
 - Mountain Duck 3.0.1 or later requires *Windows 7* or later.
-````
-`````
+
+::::
+:::::
 
 ## Registration Key
 
 Double-click the file `.mountainducklicense` to apply the license and register Mountain Duck. Alternatively, you can copy the key file to the [application support folder](../support.md#application-support-folder).
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 You can manually install the registration key in
 
 - `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/`
 
-````
-
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 You can install the registration key either in:
 
 - `%AppData%\Cyberduck`
 - `C:\Program Files\Mountain Duck`
 
-````
-`````
+::::
+:::::
 
 ### Known Issues
 
@@ -115,10 +114,14 @@ After upgrading a license, a new license file will be generated.
 3. Apply the new license file using double-click or copy the file into the application support folder.
 
 ### Windows Installation
+
 #### Error Code 0x24C 
+
 If you get the error code `0x24C` uninstall the client, reboot the system, and reinstall the client.
 
-	0x24C. A volume has been accessed for which a file system driver is required that has not yet been loaded.
+```
+0x24C. A volume has been accessed for which a file system driver is required that has not yet been loaded.
+```
 
 #### Troubleshooting 
 
@@ -129,6 +132,7 @@ For troubleshooting purposes when reaching out for support, please share the lat
 You can distribute Mountain Duck with the help of Active Directory or a system management tool like Intune on Windows or JAMF on macOS and copy the license file into the [application support folder](../support.md#application-support-folder) after installing Mountain Duck. Installation packages are provided in MSI (Windows) and PKG (macOS) formats.
 
 ### Defaults
+
 - Add preconfigured connection profiles and bookmarks this way by copying the connection profile file (`.cyberduckprofile`) into the *Profiles* folder or the bookmark file (`.duck`) into the *Bookmarks* folder within the [application support folder](../support.md#application-support-folder).
 - Share default settings by using the [default.properties file](../preferences.md#hidden-configuration-options). 
 
@@ -136,17 +140,17 @@ You can distribute Mountain Duck with the help of Active Directory or a system m
 
 Using Windows Command Line:
 
-* Regular uninstall:
+- Regular uninstall:
 	`Mountain Duck Installer-<version>.exe /uninstall`
-* Silent uninstall:
+- Silent uninstall:
 	`Mountain Duck Installer-<version>.exe /uninstall /quiet`
 
 ### Complete Uninstall
 
 Follow the steps below to uninstall Mountain Duck completely.
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 1. Close the application and navigate to the application folder using the shortcut `⌘⇧A`. Select *Mountain Duck.app* and delete the application by choosing *File → Move to Trash*.
 2. Navigate to the *Group Containers* folder within *~/Library/* and delete the folder *G69SCX94XU.duck*. If you changed the cache location you will have to delete that folder as well.
@@ -154,15 +158,13 @@ Follow the steps below to uninstall Mountain Duck completely.
 	`defaults delete io.mountainduck`
 4. **Optional:** Delete all saved login credentials regarding Mountain Duck within *Keychain Access.app*.
 
-````
-
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 1. Close the application and open the start menu using the shortcut `Ctrl Esc`. Search for *Apps & Features* and move to the entry *Mountain Duck*. Click on the application, choose *Uninstall*, and confirm your intentions by clicking *Uninstall* again.
 2. Navigate to the `%AppData%`and delete the folder *Cyberduck*
 3. Navigate to `%LocalAppData%`and delete the folder *Cyberduck*
 4. **Optional:** Delete all saved login credentials regarding Mountain Duck within *Windows Credential Manager*.
 
-````
-
-`````
+::::
+:::::

--- a/mountainduck/installation/licensing.md
+++ b/mountainduck/installation/licensing.md
@@ -1,10 +1,10 @@
 Licensing
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 Mountain Duck is licensed on a per-seat basis. Each license is valid for one user. The license can be used on multiple devices as long as the same user is accessing the application.
 
@@ -14,9 +14,9 @@ Licenses are registered to the email address in use while purchasing. Buying mor
 
 Downloading the [trial version](https://mountainduck.io/) of Mountain Duck, a license popup will open. Select `Request Trial` to download a 14-days trial license.
 
-```{note}
+:::{note}
 Please reach out to [Mountain Duck support](mailto:support@mountainduck.io) for extended trial requirements in enterprise deployments.
-```
+:::
 
 ## FAQ
 
@@ -58,9 +58,9 @@ click the registration key file to register your license. In case you make use o
 Windows to deploy Mountain Duck you might add a post-deploy action to add the license key to the installation 
 copying alongside the application.
 
-```{note}
+:::{note}
 You always receive a single registration key containing all purchased licenses for multi-user deployments.
-```
+:::
 
 ### Is the Registration Key Valid for Future Version?
 

--- a/mountainduck/interface.md
+++ b/mountainduck/interface.md
@@ -1,44 +1,44 @@
 User Interface
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## User Interface
 
 Mountain Duck runs in the status bar (macOS) and taskbar (Windows).
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
-```{image} _images/Status_Bar_Menu_Mac_Dark.png
+:::{image} _images/Status_Bar_Menu_Mac_Dark.png
 :alt: Status Bar Menu (macOS Dark)
 :width: 800px
-```
+:::
 <br/>
 <br/>
 
 Find the mounted volume in Finder. Choose *Go → Computer* or choose *Finder → General → Show these items on the desktop:* *Connected servers* to make it appear on your desktop.
 
-```{tip}
+:::{tip}
 Make sure there is enough space left on right side of the notch or application menu items to make sure the _Mountain Duck_ is visible in the the system status bar. To rearrange status menus, press and hold the Command key while you drag an icon. When having multiple displays attached to your computer the status bar item  may not be visible on the main display but on the secondary display.
-```
-````
+:::
 
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 ![Task Bar Menu Windows](_images/Task_Bar_Menu_Windows.png)
 
 Right-click on the taskbar and select *Taskbar setting → Notification area → Select which icons appear on the taskbar*. Make sure Mountain Duck is selected in the list.
 
-```{tip}
+:::{tip}
 If Mountain Duck is newly installed on a Windows 11 system, the tray icon must be revealed manually in *System Preferences → Personalization → Taskbar → Other system tray items*.
-```
-````
+:::
 
-`````
+::::
+:::::
 
 ### Auto Start
 
@@ -48,9 +48,9 @@ You can choose to automatically open Mountain Duck when logging in. Refer to [Pr
 
 Choose *Open Connection…* to add a new bookmark or *<Bookmark> → Edit Bookmark* to change properties.
 
-```{note}
+:::{note}
 Bookmarks are shared between [Cyberduck](https://cyberduck.io/) and Mountain Duck.
-```
+:::
 
 ### Connect Mode
 
@@ -58,30 +58,32 @@ Bookmarks are shared between [Cyberduck](https://cyberduck.io/) and Mountain Duc
 - **Online:** Do not synchronize any file to your computer. See [Online](connect/online.md) connect mode.
 - **Smart Synchronization:** See [Smart Synchronization](connect/sync.md) connect mode.
 
-```{image} _images/Edit_Bookmark_macOS.png
+:::{image} _images/Edit_Bookmark_macOS.png
 :alt: Edit Bookmark (macOS)
 :width: 500px
-```
-```{image} _images/Edit_Bookmark_Windows.png
+:::
+
+:::{image} _images/Edit_Bookmark_Windows.png
 :alt: Edit Bookmark (Windows)
 :width: 500px
-```
+:::
 
 ### Nickname
 
 The nickname determines the display of the bookmark in the menu and can be customized.
-```{tip}
+
+:::{tip}
 The nickname determines the name of the mounted volume in Finder.app on macOS or drive in File Explorer on Windows. Also refer to [Mount Location](preferences.md#mount-location).
-```
+:::
 
 ### Labels
 
 Assign multiple labels to bookmarks. Bookmarks are grouped in folders in the status bar menu by their assigned labels.
 
-```{image} _images/Taskbar_Menu_Bookmark_Groups_Large_Icons_Windows.png
+:::{image} _images/Taskbar_Menu_Bookmark_Groups_Large_Icons_Windows.png
 :alt: Taskbar Menu Bookmark Groups (Windows, Large Icons)
 :width: 400px
-```
+:::
 
 ### Read-Only Volume
 
@@ -91,18 +93,18 @@ Select *Options: Read Only* in the bookmark to mount the volume as read-only and
 
 Always assign the same drive letter to the mounted volume.
 
-```{note}
+:::{note}
 The number of concurrent connected bookmarks is limited by the number of available drive letters. You can have a total of 26 drives on your system.
-```
+:::
 
 ## Filter
 
 You can search for bookmarks with the filter input field in the menu. Bookmarks not matching the input are greyed out.
 
-```{image} _images/Bookmark_Search_Input.png
+:::{image} _images/Bookmark_Search_Input.png
 :alt: Bookmark Search Input
 :width: 400px
-```
+:::
 
 ## Bookmark Status
 
@@ -114,15 +116,17 @@ The bookmark can show three different status lights:
 
 You can can put the currently connected bookmarks on top of the bookmark list regardless of the sorting by using a [hidden configuration option](preferences.md#hidden-configuration-options):
 
-	bookmark.menu.sort.connected=true
+```
+bookmark.menu.sort.connected=true
+```
 
 ## Connect
 
 Choose *<Bookmark> → Connect* to mount the server as a volume in the *Finder.app* on macOS or the *File Explorer* on Windows. You can connect to multiple servers and have several volumes mounted. All operations on the remote files and folders can then be performed like on local files.
 
-```{tip}
+:::{tip}
 You can just select the menu item with the bookmark name to connect, too. If you are already connected, selecting the menu item will reveal the volume in *Finder.app*.
-```
+:::
 
 ![Screenshot Windows Mountain Duck](_images/Screenshot_Windows_Mountain_Duck.png)
 
@@ -130,20 +134,19 @@ You can just select the menu item with the bookmark name to connect, too. If you
 
 You can mount volumes using your command-line interface (CLI) by opening a bookmark file.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Use
 `open -a "Mountain Duck" ~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/Bookmarks/*.duck` in *Terminal.app*
 
-````
-
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Enter the command `<path to Mountainduck.exe> %AppData%/Cyberduck/Bookmarks/<Bookmarkfile>` in *cmd.exe*.
 
-````
-`````
+:::
+::::
 
 ## Notifications
 
@@ -154,35 +157,33 @@ Notifications of the connection status are posted to the *Notification Center* o
 - *Errors:* If there is a network connectivity issue while the remote server is mounted, an alert is displayed that allows you to retry the connection or disconnect and unmount the volume.
 - [Sync Notifications](connect/sync.md#notifications)
 
-```{image} _images/File_Added_Notification_Windows.png
+:::{image} _images/File_Added_Notification_Windows.png
 :alt: File Added Notification (Windows)
 :width: 600px
-```
+:::
 
 ## Disconnect
 
 Choose *<Bookmark> → Disconnect* to unmount a volume. Alternatively, eject the volume in *Finder.app* or *File Explorer*.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Choose *File → Eject* in *Finder.app* for the selected volume or control click to choose *Eject*.
 
 **Disconnect using command line**<br/>
 You can unmount volumes using your command-line interface (CLI). Use `umount <bookmark nickname>` in *Terminal.app*.
 
-````
-
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 In *File Explorer* in "This PC" view or the sidebar on the left of the *File Explorer* window, open the context menu for your mounted drive and select *Disconnect*.
 
 **Disconnect using command line**<br/>
 You can unmount volumes using your command-line interface (CLI). Use `net use <drive letter>: /delete` in *cmd.exe*
 
-````
-
-`````
+:::
+::::
 
 ## Copying Files
 
@@ -195,16 +196,16 @@ Drag files in *Finder.app* an macOS or *File Explorer* on Windows to move and co
 
 A context menu in *Finder* on macOS and *File Explorer* on Windows allows various actions on files.
 
-```{image} _images/Context_Menu_Windows.png
+:::{image} _images/Context_Menu_Windows.png
 :alt: Context Menu (Windows)
 :width: 600px
-```
+:::
 
-```{admonition} macOS only
+:::{admonition} macOS only
 :class: tip
 
 Please make sure to enable the Mountain Duck [Integration](#context-menu-in-finder-and-windows-file-explorer) in *System Preferences → Extensions → Finder Extensions*. For **macOS Ventura and later**, the setting can be found in *System Settings → Privacy & Security → Extensions → Added Extensions*.
-```
+:::
 
 ### Sync Options
 
@@ -215,15 +216,15 @@ Refer to [Sync Options](connect/sync.md#keep-offline).
 
 Changes from the server are not immediately visible. The folder listing in the file browser may become outdated when another application adds, removes, or modifies files on the server. Mountain Duck periodically polls for changes for open folders in _Finder.app_ on macOS or _File Explorer_ on Windows about every minute in both _Online_ and _Smart Synchronization_ connect modes. Choose *Reload* from the context menu to refresh the directory listing.
 
-```{admonition} Windows only
+:::{admonition} Windows only
 :class: tip
 
 Use _F5_ in _File Explorer_ to refresh the folder listing.
-```
+:::
 
-```{tip}
+:::{tip}
 Enable the *Index Files* option in [*Preferences → Sync*](preferences.md#index-files) to allow new files on the remote storage to be detected periodically for previously opened directories regardless of any open window for the folder in _Finder.app_ on macOS or _File Explorer_ on Windows in _Smart Synchronization_ connect mode.
-```
+:::
 
 ### Share
 
@@ -237,10 +238,10 @@ Right-click files on a mounted drive will open a menu with items to copy & open 
 
 [Read more](../cyberduck/share.md) about sharing options.
 
-```{image} _images/Mountain_Duck_Finder_Context_Menu.png
+:::{image} _images/Mountain_Duck_Finder_Context_Menu.png
 :alt: Mountain Duck Finder Context Menu
 :width: 1000px
-```
+:::
 
 ### Versions
 
@@ -255,9 +256,9 @@ Right-click on white space within the mounted drive in Finder or Explorer to add
 
 Right-click on a folder and choose *Open in Terminal* to open an SSH connection to the server in Terminal for SFTP bookmarks.
 
-```{attention}
+:::{attention}
 This feature is not supported in the version available in the Mac App Store.
-```
+:::
 
 ### Info Panel
 

--- a/mountainduck/issues/index.md
+++ b/mountainduck/issues/index.md
@@ -1,64 +1,66 @@
 Known Issues
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 
 fastcgi
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Performance Considerations
 
 To reduce the number of requests to the remote server for mounted volumes, we recommend the following settings when running in *Online* connect mode.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
+
 **Finder.app**<br/>
 
 - Choose *View → Hide Preview* (⌘⇧P)
 - Disable *View → Show View Options → Show icon preview*
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
+
 **Windows Explorer**<br/>
 Choose *File Explorer → Folder Options*.
 
 - Check *Always show icons, never thumbnails*
 - Check *Display File Icon on thumbnails*
 - Uncheck *Show preview handlers in preview pane*
-````
 
-`````
+:::
+::::
 
 ## Temporary Files
 When opening files with status _Online only_ or when connected with _Online_ connect mode, it may be required to temporarily cache contents depending on the read pattern of the application opening the file. Data is stored in the temporary file location of the operating system and allows for faster access when repeatedly reading the file. Temporary files are deleted as soon as the application closes the file after reading, unless the option _Enable buffering_ checked in _Preferences → Sync_. 
 
-```{tip}
+:::{tip}
 When enabled _Preferences → Sync → Enable buffering_ is enabled:
 * In _Online_ connect mode, buffered content in temporary files is kept until disconnecting the bookmark.
 * In _Smart Synchronization_ connect mode, the buffer contents is moved from the temporary folder to the local cache and the status of the file changes to _Up to Date_.
-```
+:::
 
 ## Filenames
 
 ### Files and Folders not Synced from Server
 Files matching the following naming pattern are excluded from folder listings and not synchronized from the server. These characters are reserved for the operating system or file system and can't be used to name files or directories.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 - `:` (colon)
 - `/` (forward slash)
 - `\` (backslash)
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 - `<` (less than)
 - `>` (greater than)
@@ -70,8 +72,8 @@ Files matching the following naming pattern are excluded from folder listings an
 - `?` (question mark)
 - `*` (asterisk)
 
-````
-`````
+:::
+::::
 
 ### Files and Folders not Uploaded to Server
 Files and folders matching temporary filename patterns are excluded from sync by default. This includes `.DS_Store`,`*~$`, `*~.*`, `._~$*`, `*.tmp`, `~*.tmp`, `*~*.TMP`, `*.swap`, `*.swp`, `.TemporaryItems`, `.dat.nosync*`, `DBTmp*`, `*.lck`, `*.idlk`, `Desktop.ini`, `Thumbs.db`, `*.crdownload`, `*.part`
@@ -81,18 +83,18 @@ Files and folders matching temporary filename patterns are excluded from sync by
 
 New empty (0-byte) files created in _Windows Explorer_ using _New → …_ are not transferred to the server. New folders created in _Finder.app_ or _Windows Explorer_ not renamed are not uploaded to the server. Change the folder name to something else than *Untitled Folder* on macOS or *New Folder* on Windows to synchronize to the server.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 In _Finder.app_: *Untitled folder* and localized variants created using _File → New Folder_
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 In _Windows Explorer_: *New folder* and localized variants created using _New → Folder_
 
-````
-`````
+:::
+::::
 
 ## Known Issues
 
@@ -136,9 +138,9 @@ The directory listing in *Finder.app* on macOS or *File Explorer* on Windows may
 * With [_Preferences → Sync → Index Files_](../preferences.md#index-files) enabled, folders previously opened are polled for changes and new files in _Smart Synchronization_ connect mode.
 * Immediately look for changes from the server when opening a new folder in _Finder.app_ on macOS or _File Explorer_ on Windows.
 
-```{tip}
+:::{tip}
 You can explicitly request to look for changes on the server in a folder by choosing *Reload* from the [context menu](../interface.md#reload).
-```
+:::
 
 ### Cache Uses a lot of Disk Space
 
@@ -148,20 +150,20 @@ The cache size can be limited per bookmark in *Preferences → Sync*. Also files
 
 The cache directory is located in `%LocalAppData%\Cyberduck\Cache` on Windows or within *Application Support folder* on macOS by default. You can [change the cache location](../preferences.md#cache-location) to any writable location. You can clear cached files from the local disk with the *Delete on local disk* [context menu](../connect/sync.md#delete-on-local-disk) option.
 
-```{image} ../_images/Custom_Location_Sync_Cache.png
+:::{image} ../_images/Custom_Location_Sync_Cache.png
 :alt: Send Command
 :width: 600px
-```
+:::
 
 ### Insufficient Disk Space 
 
 If the available disk space on the mounted volume is below 100MB a soft quota notification will be displayed saying *Insufficient space*. 
 Synchronization is paused when the soft quota is reached.
 
-```{image} ../_images/Soft_Quota_Disk_Space.png
+:::{image} ../_images/Soft_Quota_Disk_Space.png
 :alt: Soft Quota Insufficient disk space
 :width: 400px
-```
+:::
 
 This quota information is only available for the following protocols:
 - [WebDAV](../../protocols/webdav/index.md)
@@ -175,9 +177,9 @@ This quota information is only available for the following protocols:
 
 *Synology Drive* is not supported natively. You can try to view your *Synology Drive* files by connecting to your *Synology NAS*. To do that connect to your *Synology NAS* using the protocol **SFTP, FTP,** or **WebDAV** with the path `home/Drive`.
 
-```{note}
+:::{note}
 This won't allow you to view and access shared files and folders.
-```
+:::
 
 ### Graphical Artifacts with VLC player
 
@@ -185,8 +187,8 @@ Playing video files from a mounted drive using VLC player can cause graphical ar
 
 ### Missing Sync Status Icons
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 **Finder**<br/>
 When you have other applications installed that register a Finder Extension (macOS) for the volume mounted, the status icon may not appear. This has been reported for the following applications:
@@ -198,23 +200,24 @@ When you have other applications installed that register a Finder Extension (mac
 
 Please check in *System Preferences → Extension → Finder* for other applications that may override the badge icons. For **macOS Ventura and later**, the setting can be found in *System Settings → Privacy & Security → Extensions → Added Extensions*.
 
-```{note}
+:::{note}
 If none of those applications are in use, a Finder re-launch can make the badge icons appear again.
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 **Explorer**<br/>
 Windows has a limitation on the number of applications that can register for bagde icons in File Explorer. You will need to either uninstall other applications or edit your registry key `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\ShellIconOverlayIdentifiers`.
 You can find this well documented by Microsoft at [Sync icon overlays are missing](https://support.office.com/en-us/article/sync-icon-overlays-are-missing-from-onedrive-and-onedrive-for-business-b25070ab-2226-4ad8-b1fc-ae28cc44ecd2).
-````
-````` 
+
+::::
+::::: 
 
 ### Operating System Specific Issues
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 **Missing Status Bar Icon**<br/>
 Using applications customizing the status menus may lead to a missing status icon of Mountain Duck. This has been reported for the following applications:
@@ -234,7 +237,9 @@ Files opened in Preview.app and edited cannot be saved at the original location 
 **Enable Application Icon in Dock**<br/>
 As a utility application with no application windows, no icon is displayed in the Dock but only in the system status bar. If you want to enable the application icon to appear in the Dock set the following property:
 
-    defaults write io.mountainduck application.dock.icon.enable true
+```
+defaults write io.mountainduck application.dock.icon.enable true
+```
 
 **Mounted Volumes do not Appear on the Desktop**<br/>
 Navigate to volumes using `⌘⇧C` in a *Finder.app* window or choose *Finder → Preferences ... → General → Show these items on the desktop: Connected Servers* to make the volume appear on the desktop. Mounted volumes are also listed in the *Finder.app* sidebar in *Favorites*.
@@ -244,10 +249,10 @@ The Spotlight search does not work on remote volumes.
 
 **Spotlight Indexer**<br/>
 To prevent the indexing through Spotlight the default mount location has been changed to `Volumes.noindex`. In case you **do** want the mount location to be indexed by Spotlight, use the *Terminal.app* command `mdutil -i on <mount location>`. Additionally, [mount location](../preferences.md#mount-location) to a directory without the extension `.noindex`.
-```{attention}
-Enabling Spotlight can cause high CPU and bandwidth usage while indexing folders. 
-```
 
+:::{attention}
+Enabling Spotlight can cause high CPU and bandwidth usage while indexing folders. 
+:::
 
 **Multiple Mountain Duck Finder Extensions Processes**<br/>
 The system may launch additional copies of *Mountain Duck Finder Extension* whenever an Open or Save dialog is displayed. This means there may be multiple copies of the extension running at once, and some may be very short-lived.
@@ -260,11 +265,12 @@ This is an issue within the operating system that can occur to any network drive
 **Extended Attributes**<br/>
 Extended attributes containing metadata about the files some applications write in addition to the file content are saved in auxiliary `._*` files. These are only saved in a temporary location and not synchronized. If you want to save `._*` files to the server set the [hidden configuration option](../preferences.md#hidden-configuration-options):
 
-    defaults write io.mountainduck fs.filenames.metadata.enable false
+```
+defaults write io.mountainduck fs.filenames.metadata.enable false
+```
 
-
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
 **File System Driver isn't set up Properly**<br/>
 Error: `A volume has been accessed for which a file system driver is required that has not yet been loaded`
@@ -300,7 +306,9 @@ You can close that overlay by holding your mouse cursor for about 3 seconds on t
 **Dot Files are not Hidden**<br/>
 By default, files starting with `.` aren't hidden by Windows Explorer. You can change the default by using a [hidden configuration option](../preferences.md#hidden-configuration-options).
 
-    browser.hidden.regex=\\..*
+```
+browser.hidden.regex=\\..*
+```
 
 **Robocopy Timestamp Accuracy**<br/>
 Windows has a sub-second timestamp accuracy while protocols like SFTP have an accuracy of a second. This discrepancy causes unnecessary transfers when subsequent runs find non-matching timestamps on unchanged files. 
@@ -309,9 +317,8 @@ Using the command `robocopy /MIR /FFT` instead of `robocopy /MIR` fixes the beha
 
 Additional information on *robocopy* can be found in the microsoft [documentation](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy).
 
-````
-
-`````
+::::
+:::::
 
 ## Interoperability
 
@@ -342,20 +349,20 @@ May interfere with installation.
 
 ### Backups
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 **Time Machine**<br/>
 Backups to Time Machine do not work with volumes mounted from Mountain Duck. Time Machine requires disks mounted using Apple File Protocol (AFP). See [Backup disks you can use with Time Machine](https://support.apple.com/en-us/HT202784).
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 **Windows Backup**<br/>
 Volumes mounted with Mountain Duck cannot be used by *Windows Backup*. It can only save backups on destinations that are located within your local system or within your local network.
 
-````
-`````
+:::
+::::
 
 ## Bug Reports and Feature Requests
 

--- a/mountainduck/locking.md
+++ b/mountainduck/locking.md
@@ -12,9 +12,9 @@ File locking is natively supported for the following protocols:
 - [Microsoft SharePoint](../protocols/sharepoint.md)
 - [WebDAV](../protocols/webdav/index.md)
 
-```{note}
+:::{note}
 Some WebDAV implementations may not support locking documents.
-```
+:::
 
 Files opened from one of the supported protocols are locked for editing by other users. Mountain Duck locks files on the server when opened in an editor. This prevents other users from modifying the document until the file is closed by the user.
 
@@ -22,13 +22,13 @@ Files opened from one of the supported protocols are locked for editing by other
 
 For connections other than [WebDAV](../protocols/webdav/index.md), we support detecting files opened by others by looking for owner lock files uploading to the server.
 
-```{note}
+:::{note}
 Support is currently limited to files edited in *Microsoft Word, Microsoft Excel, and Microsoft Powerpoint* on macOS and Windows.
-```
+:::
 
-```{attention}
+:::{attention}
 *Excel 97-2003* files are not included because Excel doesn't create lock files for those file types: `*.xls`, `*.xlt`, `*.xla`.
-```
+:::
 
 ### References
 
@@ -41,67 +41,68 @@ When a previously saved file is opened for editing, for printing, or for review,
 
 Attempting to open a locked document, an error message is displayed notifying the document can only be opened in read-only mode. Samples of error messages from different applications.
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
+
 **Microsoft Word**<br/>
 `Read Only. To save a copy of this document, click Duplicate`
 
-```{image} _images/Read_Only_Microsoft_Word_macOS.png
+:::{image} _images/Read_Only_Microsoft_Word_macOS.png
 :alt: Read Only Microsoft Word (macOS)
 :width: 500px
-```
+:::
 
 **Libre Office**<br/>
 `Document ... is locked for editing by... . Open document read-only or open a copy of the document for editing.`
 
-```{image} _images/Document_in_Use_Libre_Office_macOS.png
+:::{image} _images/Document_in_Use_Libre_Office_macOS.png
 :alt: Document in Use Libre Office (macOS)
 :width: 400px
-```
+:::
 
-```{image} _images/Read_Only_Mode_Libre_Office_macOS.png
+:::{image} _images/Read_Only_Mode_Libre_Office_macOS.png
 :alt: Read Only Mode Libre Office (macOS)
 :width: 400px
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 `This file is already opend by another user. Would you like to make a copy of this file for your use?`
 
-```{image} _images/File_in_Use_Microsoft_Word_Windows.png
+:::{image} _images/File_in_Use_Microsoft_Word_Windows.png
 :alt: File in Use Microsoft Word (Windows)
 :width: 400px
-```
+:::
 
 Choose *Receive notification when the original copy is available* to open the document in read-only mode and get an alert when the other user has closed the document.
 
-```{image} _images/Microsoft_Word_Read-Only_Edit_Windows.png
+:::{image} _images/Microsoft_Word_Read-Only_Edit_Windows.png
 :alt: Read Only Edit Microsoft Word (Windows)
 :width: 400px
-```
+:::
 
-```{image} _images/Microsoft_Word_File_Now_Available_Windows.png
+:::{image} _images/Microsoft_Word_File_Now_Available_Windows.png
 :alt: File Now Available Microsoft Word (Windows)
 :width: 400px
-```
+:::
 
 **Microsoft Excel**<br/>
 `File in Use: File is locked for editing by ... . Open 'Read-Only' or click 'Notify' to open read-only and receive notification when the document is no longer in use.`
 
-```{image} _images/Read_Only_Microsoft_Excel_Windows.png
+:::{image} _images/Read_Only_Microsoft_Excel_Windows.png
 :alt: Read Only Microsoft Excel (Windows)
 :width: 400px
-```
+:::
 
 Choose *Notify* to open the document in read-only mode and get an alert when the other user has closed the document.
 
-```{image} _images/Microsoft_Excel_File_Now_Available_Notification_Windows.png
+:::{image} _images/Microsoft_Excel_File_Now_Available_Notification_Windows.png
 :alt: File Now Available Notification Microsoft Excel
 :width: 400px
-```
+:::
 
-````
-`````
+::::
+:::::
 
 ## Resolution
 

--- a/mountainduck/preferences.md
+++ b/mountainduck/preferences.md
@@ -1,35 +1,42 @@
 Preferences
 ====
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## General
+
 ### Save Workspace
+
 Save all mounted volumes when quitting to be restored while relaunching.
 
 ### Bookmarks
+
 Change the size of the menu items in the status bar menu. Choose between *Small, Medium,* and *Large* icons.
 
 ## Sync
+
 ### Connect Mode
+
 Change the default synchronization option. You can disable synchronization by default for all bookmarks by switching to *Online*. Refer to [Connect Mode](interface.md#connect-mode)
 
-```{image} _images/Sync_Preferences_Win.png
+:::{image} _images/Sync_Preferences_Win.png
 :alt: Sync Preferences
 :width: 700px
-```
+:::
 
 ### Index Files
+
 Index files on the server for a mounted connection in the background after connecting to ensure you can browse all directories when offline. Enabling this option will make sure new files available on the remote storage are detected without [manually](interface.md#reload) choosing *Reload* in the context menu. When enabled, remote directories previously opened are polled for changes and new files periodically every 10 minutes. 
 
-```{warning}
+:::{warning}
 This feature is not available in *Online* connect mode. You cannot browse folders or open files as soon as the server connection gets interrupted.
-```
+:::
 
 ### Enable Buffering
+
 Choose whether the file contents should be buffered. The option allows buffering file contents in a temporary location which is only deleted when quitting the application.
 - Allows faster access when reading or writing files with random access patterns from applications in _Online_ [mode](interface.md#connect-mode).
 - With the option enabled in _Smart Synchronization_ [mode](interface.md#connect-mode), buffered file contents will be copied to the cache and the file can be opened when offline. Refer to [Status of Files](connect/sync.md#status-of-files).
@@ -39,14 +46,14 @@ Choose whether the file contents should be buffered. The option allows buffering
 Buffered files are saved in `%temp%` for Windows or in `/private/tmp` for macOS.
 
 ### Lock Files
+
 Enable to prevent conflicting edits when accessing documents from a shared environment. Refer to [File Locking](locking.md).
 
 ### Mount Location 
 
-```{attention} 
-
+:::{attention} 
 The setting is not available in the App Store version. Make sure to change the mount location back to default before using the App Store version of Mountain Duck otherwise you may experience permission issues.
-```
+:::
 
 Volumes are mounted in the *Volumes* folder in the [application support directory](support.md). You can change the default to another folder that is writable.
 
@@ -54,33 +61,39 @@ Volumes are mounted in the *Volumes* folder in the [application support director
 
 #### Show Volumes on Desktop
 
-`````{tabs}
-````{group-tab} macOS
+::::{admonition} macOS
+:class: attention
+
 Part of a workaround for a bug in macOS 14.4 and later displaying volumes as "/" or ":" respectively, Mountain Duck 4.15.4 no longer displays volumes on the desktop or in the Location sidebar in Finder.app by default regardless of the setting in _Finder → Settings… → General_. You can reverse the display of the volumes on the desktop and the Locations section in the sidebar in Finder.app using a [hidden configuration option](#hidden-configuration-options).
 
-	fs.nfs.mount.nobrowse=false
-
-```{note}
-Due to the bug introduced by Apple in macOS 14.4, the volume will always display as `:` in the _Network_ section of Finder.app until a bugfix is provided by Apple.
 ```
-````
-`````
+fs.nfs.mount.nobrowse=false
+```
+
+:::{note}
+Due to the bug introduced by Apple in macOS 14.4, the volume will always display as `:` in the _Network_ section of Finder.app until a bugfix is provided by Apple.
+:::
+
+::::
 
 ### Cache Location
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
+
 Change the location where to store cache files required for offline access. By default the *Cache* folder is in the [application support directory](support.md). The disk must be formatted as HFS+ or APFS.
-````
 
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
+
 Change the location where to store cache files required for offline access. By default the *Cache* folder is in `%LocalAppData%\Cyberduck`. You must select NTFS formatted drives with support for *NTFS Alternate Data Stream (ADS)*. FAT, FAT32, exFAT, and similar formatted drives are not supported. Network drives may not support alternate data streams as well.
-````
-`````
 
-```{warning}
+:::
+::::
+
+:::{warning}
 Do not manually move, delete or modify files in the obfuscated local cache location.
-```
+:::
 
 #### Cache Limitations
 
@@ -90,86 +103,96 @@ The following options are available:
 - **Limit by size**. Limit cache size per bookmark by selecting a maximum folder size within the preference. Exceeding the maximum cache size, larger files are purged first.
 - **Limit by time**. Purge files not accessed within a selected period of time automatically.
 
-```{tip}
+:::{tip}
 Files selected to always keep offline are never automatically removed from the cache.
-```
+:::
 
 By default, files are kept in cache for 30 days and the cache is limited to a maximum size of 5GiB.
 
-```{attention}
+:::{attention}
 The settings apply separately for each bookmark. The synchronization cache gets cleared based on the chosen cache limit after Mountain Duck is started and every 24h as long as Mountain Duck is running.
-```
+:::
 
 ## Notifications
 
 Set which type of notifications you want to receive. Alternatively, you can choose *Open System Preferences* to disable the notifications all together. 
 
-```{image} _images/Notification_Preferences.png
+:::{image} _images/Notification_Preferences.png
 :alt: Notification Preferences
 :width: 700px
-```
+:::
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
 You can disable notifications in *System Preferences → Notifications*. Choose *None* for alert style and keep checked *Show* in *Notification Centre*. This way you will no longer be disturbed by any notification displays, but can still check back the notifications in *Notification Centre* anytime if required.
-````
-````{group-tab} Windows
+
+::::
+::::{group-tab} Windows
 
 You can disable notifications in *Settings → System → Notifications and Actions*. Uncheck *Show notification banners* and *Play a sound when a notification arrives*. Keep *Show notifications in action center* to see the notifications in Windows action center anytime if required.
-````
-`````
+
+::::
+:::::
 
 ## Profiles
+
 Select connection profiles to be installed. Either scroll through the list or use the search function to look for a specific profile. The connection profiles will be installed after ticking the corresponding checkboxes. Installed protocols are displayed in the protocol dropdown menu in the bookmark window. To disable the connection profile simply untick the checkbox. 
 
-```{image} _images/Profiles_Preferences.png
+:::{image} _images/Profiles_Preferences.png
 :alt: Profiles Preferences
 :width: 700px
-```
+:::
 
 ### Default Connection Profiles
+
 The connection profiles for [default protocols](../protocols/index.md) are always enabled.
 
 ## Login Item
+
 Reconnect after restarting the computer. If you choose *Enable Login Item* and *Save Workspace* in *Preferences → General* and do not manually eject the volume prior to reboot it will reconnect after login.
 
 ## Cryptomator
+
 Choose whether or not your [Cryptomator vaults](../cryptomator/index.md) should be auto detected and unlocked while browsing the parent folder or not by using the *Auto detect and open vault in browser* option.
 
-```{note}
+:::{note}
 Without saving the vaults passwords using keychain, you will receive passwords prompts for the vaults after reconnecting to the server or cloud storage.
-``` 
+:::
 
 ### Use Keychain
+
 Specify if you want the *Save Password* option enabled by default while entering the password to unlock your vault. With the option disabled you have to check the checkbox to save the password in keychain manually. 
 
 ## Updates
+
 An auto-update feature will alert you when a new version is available and self updates the application. Choose *Preferences → Automatically check for updates*. You can also choose to update to snapshot or beta builds.
 
 - **Snapshot builds:** Include the latest changes and are published continuously. These builds are not manually tested.
 - **Beta builds:** Published before a release and include the latest features and have been tested but might not have release quality yet.
 
-```{admonition} Windows only
+:::{admonition} Windows only
 :class: tip
+
 You receive no update notification if your user is missing administrator permission.
-```
+:::
 
 ## Hidden Configuration Options
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 - Type the `defaults` command given in a *Terminal.app* (in `/Applications/Utilities`) window and restart Mountain Duck.
 `defaults write io.mountainduck <property> <value>`
 - Alternatively, create a file `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/default.properties` with the content formatted as `property=value`
-````
-````{group-tab} Windows
+
+:::
+:::{group-tab} Windows
 
 If not existing yet you need to create the file `%AppData%\Cyberduck\default.properties`. Add the setting as follows:<br/>
 `property=value`
 
 These settings are shared with Cyberduck.
-````
 
-`````
+:::
+::::

--- a/mountainduck/share.md
+++ b/mountainduck/share.md
@@ -1,2 +1,2 @@
-```{include} ../cyberduck/share.md
-```
+:::{include} ../cyberduck/share.md
+:::

--- a/mountainduck/support.md
+++ b/mountainduck/support.md
@@ -5,20 +5,20 @@ Support
 
 Inside the application support folder, the application saves files needed for their operations e.g. settings, log data, history files, etc.
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 You can reach the application support folder by choosing `Go → Go to folder` within the *Finder* menu, copying the path below into the appearing window, and clicking on the *Open* button afterward.
 
 `~/Library/Group Containers/G69SCX94XU.duck/Library/Application Support/duck/`
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 You can reach the application support folder by navigating to `%AppData%\Cyberduck` by copying the path into the address bar of the Explorer and press *Return* afterward.
 
-````
-`````
+:::
+::::
 
 ## Bug Reports and Feature Requests
 
@@ -26,18 +26,18 @@ You can reach the application support folder by navigating to `%AppData%\Cyberdu
 
 ### Logging Output
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Log output can be found in the `mountainduck.log` file in`~/Library/Logs/Mountain Duck`. You can easily reach this file in _Console.app_ (Open from `/Applications/Utilities`) under `Reports → Log Reports → mountainduck.log`. Select _Show_ in _Mountain Duck → Preferences → Connection_ to reveal the log file.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Log output can be found in the `mountainduck.log` file in `%AppData%\cyberduck`. Select _Show_ in _Mountain Duck → Preferences → Connection_ to reveal the log file named *mountainduck.log*.
 
-````
-`````
+:::
+::::
 
 #### Debug Log
 
@@ -51,11 +51,9 @@ It can be reached by clicking on the Show button within _Mountain Duck → Prefe
 
 #### Installation Log
 
-```{admonition} Windows only
-Windows only
-```
-
+:::{admonition} Windows only
 The installation log contains records of all actions performed by the setup program and by other executable files related to installation. It is required for troubleshooting if you encounter errors during the installation process. The installation log file prefixed `Mountain Duck_` can be found in `%Temp%`.
+:::
 
 ### Feature Request
 
@@ -63,18 +61,18 @@ Please make sure to include a detailed description of the feature you'd like to 
 
 ## Crash Reports
 
-`````{tabs}
-````{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Crash reports are saved to `~/Library/Logs/DiagnosticReports/Mountain Duck_*.crash`. On macOS 12 or later crash reports are saved to `~/Library/Logs/DiagnosticReports/Mountain Duck_*.ips`.
 
-````
-````{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Crash reports are saved to `%AppData%\cyberduck\CrashReporter`.
 
-````
-`````
+:::
+::::
 
 ## Get Support
 

--- a/mountainduck/versions.md
+++ b/mountainduck/versions.md
@@ -1,9 +1,9 @@
 File Versions
 ====
 
-```{note}
+:::{note}
 Mountain Duck 4.12 or later required. Previously versions could be accessed from the [context menu](interface.md#context-menu-in-finder-and-windows-file-explorer) by right-clicking on a file in *Finder* on macOS or *File Explorer* on Windows and choosing *Versions*.
-```
+:::
 
 A list of file versions can be viewed within the *Versions* tab of the *[Info](../cyberduck/info.md#versions)* window. The files can also be reverted to a chosen version of the list.
 
@@ -23,20 +23,21 @@ The versions feature within the *Info* window is supported for the following pro
 | **[Dropbox](../protocols/dropbox.md)** | ✅ | ✅ | ❌ |
 | **[Nextcloud & ownCloud](../protocols/webdav/nextcloud.md)** | ✅ | ✅ | ❌ |
 
-```{attention}
+:::{attention}
 Using [S3](../protocols/s3/index.md) versions will only be displayed for buckets with versioning enabled. Versioning can be enabled per bucket in by choosing *Info → S3* in *Finder* on macOS or *File Explorer* on Windows. Alternatively, enable versioning in AWS Console or [Cyberduck](../cyberduck/index.md).
-```
+:::
 
- ### Revert
+### Revert
 
 You can revert to a previous version of a file by choosing *Versions → ... → Revert*. Wait for the *File Updated* notification which notifies the previous version has been restored.
 
-```{image} _images/File_Updated_Notification_Windows.png
+:::{image} _images/File_Updated_Notification_Windows.png
 :alt: File Updated Notification (Windows)
 :width: 400px
-```
+:::
 
-### Delete 
+### Delete
+
 Permanently delete a previous version of the selected file.
 
 ### Preview 

--- a/protocols/azure.md
+++ b/protocols/azure.md
@@ -1,10 +1,10 @@
 Windows Azure Blob Storage
 ====
 
-```{image} _images/azure.png
+:::{image} _images/azure.png
 :alt: Azure Blob Storage
 :width: 128px
-```
+:::
 
 > Massively scalable object storage for unstructured data
 
@@ -14,9 +14,9 @@ Windows Azure Blob Storage
 
 Edit the hostname to connect to your account in the format `<account>.blob.core.windows.net`.
 
-```{warning}
+:::{warning}
 Azure Files Storage is not supported.
-```
+:::
 
 ### Credentials
 
@@ -34,11 +34,15 @@ You can use a [SAS](https://docs.microsoft.com/en-us/azure/storage/common/storag
 
 You can list all containers with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --username <storageaccount> --list azure://<storageaccount>.blob.core.windows.net/`
+```
+duck --username <storageaccount> --list azure://<storageaccount>.blob.core.windows.net/`
+```
 
 For a storage account named `kahy9boj3eib` that would be 
 
-	duck --username kahy9boj3eib --list azure://kahy9boj3eib.blob.core.windows.net/
+```
+duck --username kahy9boj3eib --list azure://kahy9boj3eib.blob.core.windows.net/
+```
 
 Refer to the [Cyberduck CLI](../cli/index.md) documentation for more operations.
 
@@ -53,6 +57,7 @@ You can edit ACLs in *File → Info (macOS `⌘I` Windows `Alt+Return`) → Perm
 To create a new container in your account, browse to the root and choose *File → New Folder... (macOS `⇧⌘N` Windows `Ctrl+Shift+N`)*.
 
 ## Blob Type
+
 Uploads are stored as append blob type by default. You can use the [hidden configuration option](../cyberduck/preferences.md#hidden-configuration-options) `azure.upload.blobtype` which allows the values `BLOCK_BLOB`, `PAGE_BLOB` and `APPEND_BLOB`.
 
 ## Metadata
@@ -63,7 +68,9 @@ You can edit standard custom metadata. Choose *File → Info → Metadata* to ed
 
 Currently only possible using a [hidden configuration option](../cyberduck/preferences.md#hidden-configuration-options) you can define default headers to be added for uploads. Multiple headers must be separated using a whitespace delimiter. Key and value of a header are separated with `=`. For example, if you want to add an HTTP header for `Cache-Control` and one named `Creator` you would set
 
-	defaults write ch.sudo.cyberduck azure.metadata.default "Cache-Control=public,max-age=86400 Creator=Cyberduck"
+```
+defaults write ch.sudo.cyberduck azure.metadata.default "Cache-Control=public,max-age=86400 Creator=Cyberduck"
+```
 
 ### Shared Access Signature URLs
 
@@ -71,18 +78,18 @@ A private object stored in Azure Storage can be made publicly available for a li
 
 ![Shared Access Signature URLs](_images/Azure_Shared_Access_Signature_URLs.png)
 
-```{note}
+:::{note}
 Currently only signed URLs with a validity of 24 hours are available.
-```
+:::
 
 ### Access Logs
 
 Configure access logging for buckets in the *Info* panel.
 
-```{image} _images/Azure_tab_info_macOS.png
+:::{image} _images/Azure_tab_info_macOS.png
 :alt: Windows Azure Blob Storage
 :width: 500px
-```
+:::
 
 ## Limitations
 

--- a/protocols/b2.md
+++ b/protocols/b2.md
@@ -5,10 +5,10 @@ Backblaze B2
 
 > [Backblaze B2 Cloud Storage](https://www.backblaze.com/b2/cloud-storage.html) works similar to Amazon S3 or Microsoft Azure, allowing you to store unlimited data in the cloud. But does it for 1/4th the cost.
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Connecting
 
@@ -36,38 +36,43 @@ Use your `Key ID` and `Application Key` to log in. The application key can be re
 4. Specify the key settings and permissions and click on *Create New Key*
 5. After the Application Key is created, a blue panel is displayed containing the `Key ID` and `Application Key` for the newly generated key.
 
-```{important}
+:::{important}
 The key information will only appear once. Copy the information somewhere safe for later retrieval.
-```
+:::
 
 ### Using S3 Compatible API
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 The following [account regions](https://www.backblaze.com/docs/cloud-storage-data-regions) are available:
 
 #### US West
+
 - {download}`Download<https://profiles.cyberduck.io/Backblaze%20B2%20(S3%20compatible%20API%20us-west-000).cyberduckprofile>` the *Backblaze B2 (S3 compatible API us-west-000) Connection Profile* for preconfigured settings.
 - {download}`Download<https://profiles.cyberduck.io/Backblaze%20B2%20(S3%20compatible%20API%20us-west-001).cyberduckprofile>` the *Backblaze B2 (S3 compatible API us-west-001) Connection Profile* for preconfigured settings.
 - {download}`Download<https://profiles.cyberduck.io/Backblaze%20B2%20(S3%20compatible%20API%20us-west-002).cyberduckprofile>` the *Backblaze B2 (S3 compatible API us-west-002) Connection Profile* for preconfigured settings.
 
 #### US East
+
 - {download}`Download<https://profiles.cyberduck.io/Backblaze%20B2%20(S3%20compatible%20API%20us-east-005).cyberduckprofile>` the *Backblaze B2 (S3 compatible API us-east-005) Connection Profile* for preconfigured settings.
 
 #### EU Central
+
 - {download}`Download<https://profiles.cyberduck.io/Backblaze%20B2%20(S3%20compatible%20API%20eu-central-003).cyberduckprofile>` the *Backblaze B2 (S3 compatible API eu-central-003) Connection Profile* for preconfigured settings. 
 
-```{Attention}
+:::{Attention}
 Buckets created prior to May 4th, 2020 are not S3 compatible and cannot be accessed
-```
+:::
 
 ## Cyberduck CLI
 
 You can list all buckets with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --username <application key> --list b2:/
+```
+duck --username <application key> --list b2:/
+```
 
 Refer to the [Cyberduck CLI](../cli/index.md) documentation for more operations.
 
@@ -103,15 +108,17 @@ You can view all revisions of a file in the browser by choosing *View → Show H
 
 A list of file versions can be viewed in the *Versions* tab of the *[Info](../cyberduck/info.md#versions)* window. Files can be reverted to a chosen version of this list. Additionally, versions of the list can be deleted.
 
-```{note}
+:::{note}
 `Bucket Versioning` has to be enabled within the *B2* tab of the *Info* window before the versions of the files are displayed.
-```
-```{image} _images/B2_tab_info_macOS.png
+:::
+
+:::{image} _images/B2_tab_info_macOS.png
 :alt: Backblaze B2
 :width: 500px
-```
+:::
 
 ### Authorized URL
+
 Create an authorized URL to make files available publicly. Choose *File → Share…*. The shared URL expires in 7 days.
 
 ### Large File Uploads
@@ -155,6 +162,7 @@ Create download [shares](../cyberduck/share.md#backblaze-b2) of files for people
 The modification date retention is supported using `src_last_modified_millis` for new files uploaded but without the option to adjust the modification date later.
 
 ### Rename and Move Files
+
 <del>not supported.</del> Supported in Cyberduck 7 or later.
 
 ## References

--- a/protocols/box.md
+++ b/protocols/box.md
@@ -1,14 +1,14 @@
 Box.com
 ====
 
-```{image} _images/box.png
+:::{image} _images/box.png
 :alt: Box Drive Icon
 :width: 128px
-```
+:::
 
-```{tip}
+:::{tip}
 Download [Mountain Duck](https://mountainduck.io/) as an alternative to *Box Drive*.
-```
+:::
 
 > [Box](https://box.com/) Simple, secure file sharing and collaboration from anywhere.
 
@@ -20,9 +20,9 @@ Use the default *Box* connection profile to connect to your server using the Box
 
 #### FTP
 
-```{important}
+:::{important}
 Only available for Box business and enterprise accounts
-```
+:::
 
 Enter the following information in the [bookmark](../cyberduck/bookmarks.md):
 
@@ -33,9 +33,9 @@ Enter the following information in the [bookmark](../cyberduck/bookmarks.md):
 
 #### WebDAV
 
-```{warning}
+:::{warning}
 Box WebDAV support reached end-of-life at October 25th, 2019
-```
+:::
 
 1. {download}`Download<https://svn.cyberduck.ch/trunk/profiles/Box.cyberduckprofile>` the *Box Connection Profile* or install it from *Preferences… → Profiles* for preconfigured settings.
 2. Enter your email address for the username.
@@ -50,9 +50,9 @@ Alternatively, enter the following information in the [bookmark](../cyberduck/bo
 
 ## Share
 
-```{note}
+:::{note}
 Only available using the default *Box* connection profile.
-```
+:::
 
 Create download [shares](../cyberduck/share.md#box) of files or folders for people who are not Box users by using *File → Share...*.
 

--- a/protocols/cdn/akamai.md
+++ b/protocols/cdn/akamai.md
@@ -32,9 +32,9 @@ You can assign a default root object for your distribution. This default object 
 
 You can access all URLs (including from CDN configurations) from the menu *Edit → Copy URL* and *File → Open URL*. 
 
-```{note}
+:::{note}
 You must first open *File → Info → Distribution (CDN)* before these URLs are available.
-```
+:::
 
 ![Copy URL](_images/Copy_URLs.png)
 

--- a/protocols/cdn/cloudfront.md
+++ b/protocols/cdn/cloudfront.md
@@ -3,9 +3,9 @@ Amazon CloudFront Support
 
 Amazon CloudFront delivers your static and streaming content using a global network of edge locations. Requests for your objects are automatically routed to the nearest edge location, so content is delivered with the best possible performance. You can enable download or streaming distributions using *File → Info → Distribution* for a [S3](../s3/index.md) bucket or a custom origin distribution for any other source.
 
-```{note}
+:::{note}
 Using CloudFront can be more cost effective if your users access your objects frequently because, at higher usage, the price for CloudFront data transfer is lower than the price for Amazon S3 data transfer. In addition, downloads are faster with CloudFront than with Amazon S3 alone because your objects are stored closer to your users.
-```
+:::
 
 ## Permissions
 
@@ -25,20 +25,21 @@ Delivery method _Website Configuration (HTTP)_ to enable a [website endpoint](..
 
 Delivery method _Website Configuration (HTTP) CDN_  is using a custom origin CDN distribution with a [website endpoint](../s3/index.md#website-configuration) as a source to make use of the website endpoint features in CloudFront.
 
-```{attention}
+:::{attention}
 You must also enable the website endpoint using the delivery method _Website Configuration (HTTP)_ to make sure the CloudFront edge locations can fetch the content from the origin.
-```
+:::
 
 ## References
 
 - [Using CloudFront with the new Amazon S3 static website hosting features](https://forums.aws.amazon.com/ann.jspa?annID=921)
 
 ## Streaming (RTMP) Distributions
+
 Delivery method _Streaming (RTMP) CDN)_ used to serve [media](http://en.wikipedia.org/wiki/Flash_Video) using a [streaming protocol](http://en.wikipedia.org/wiki/Real_Time_Messaging_Protocol).
 
-```{attention}
+:::{attention}
 Discontinued on December 31, 2020 within CloudFront. For further information refer to the [AWS announcement](https://forums.aws.amazon.com/ann.jspa?annID=7356).
-```
+:::
 
 ### Playback Configuration
 
@@ -73,15 +74,18 @@ The first time your content is served to a worldwide user (one in Tokyo, for exa
 | CDN CNAME URL | http://cdn.cyberduck.ch/img/cyberduck.icon.png | URL for resource in CDN with custom hostname registered in the DNS |
 
 ## Options
+
 Refer to [Info](../../cyberduck/info.md#cdn-panel) for configuration options.
 
 ## Copy URLs
+
 CloudFront URLs are available in the regular *Copy URL* menu. Refer to [Open or Copy HTTP URL](../../cyberduck/browser.md#open-or-copy-http-url).
 
 ## Access S3 through CloudFront
+
 You can access S3 buckets through CloudFront. Although not a typical use case, this may be of interest to save bandwidth costs when working with files in S3. For example using [Cyberduck CLI](../../cli/index.md).
 
-```{code-block}
+```
 duck --user anonymous --list s3://djynunjb246r8.cloudfront.net/
 ```
 

--- a/protocols/cdn/index.md
+++ b/protocols/cdn/index.md
@@ -1,13 +1,13 @@
 Content Delivery Network (CDN) Configuration
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 akamai
 cloudfront
 keycdn
-```
+:::
 
 A content delivery network or content delivery network (CDN) allows the distribution of files from locations all over the world using a network of edge locations. Requests for files are automatically routed to the nearest edge location. Two of the main market players are supported from within Cyberduck with a simple to use interface to enable distributions with a single click of a button.
 

--- a/protocols/dracoon.md
+++ b/protocols/dracoon.md
@@ -3,10 +3,10 @@ DRACOON
 
 Cloud service made in Germany. DRACOON as a Cloud Service in ISO 27001 certified data centers.
 
-```{image} _images/dracoon.png
+:::{image} _images/dracoon.png
 :alt: DRACOON Drive Icon
 :width: 128px
-```
+:::
 
 > [DRACOON](https://www.dracoon.com/en/home#) is a highly secure, platform-independent enterprise file sharing solution, which has repeatedly won awards as a market leader. It is certified according to the highest compliance guidelines. Unique to the solution is the own developed TripleCrypt technology with end-to-end encryption as well as the authorization system for high demands in the enterprise business environment.
 
@@ -21,9 +21,9 @@ Open a [free account](https://www.dracoon.com/en/free) with 10 users including 1
 - {download}`Download<https://profiles.cyberduck.io/DRACOON%20(OAuth).cyberduckprofile>` the *DRACOON (OAuth) connection profile*.
 - {download}`Download<https://profiles.cyberduck.io/DRACOON%20(CLI).cyberduckprofile>` the *DRACOON (OAuth Password Flow) connection profile*.
 
-```{note}
+:::{note}
 The DRACOON (OAuth) connection profile is bundled by default with Cyberduck.
-```
+:::
 
 ### Authentication With Username and Password 
 

--- a/protocols/dropbox.md
+++ b/protocols/dropbox.md
@@ -1,14 +1,14 @@
 Dropbox
 ====
 
-```{image} _images/dropbox.png
+:::{image} _images/dropbox.png
 :alt: Dropbox Drive Icon
 :width: 128px
-```
+:::
 
-```{tip}
+:::{tip}
 Access your [Dropbox](https://db.tt/49NiK95I) without syncing to your computer. Download [Mountain Duck](https://mountainduck.io/) as an alternative to *Dropbox Client*.
-```
+:::
 
 ## Connecting
 
@@ -22,10 +22,11 @@ Access your [Dropbox](https://db.tt/49NiK95I) without syncing to your computer. 
 
 4. The authorization code will be submitted to Cyberduck automatically.
 
-```{admonition} Multiple Accounts
+:::{admonition} Multiple Accounts
 :class: tip
+
 You can connect to multiple accounts at the same time. Create a new bookmark for every account and run through the OAuth flow. Make sure to log out in your browser prior to setting up a new bookmark to make sure the new bookmark is linked to a newly authenticated account.
-```
+:::
 
 ### Reset OAuth Tokens
 
@@ -35,7 +36,9 @@ If you have accidentally logged in with the wrong Dropbox Account or want to cha
 
 You can list the root contents of your Dropbox with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --list dropbox:/
+```
+duck --list dropbox:/
+```
 
 Refer to the [Cyberduck CLI](../cli/index.md) documentation for more operations. For subsequent invocations make sure to include the `--username` parameter and set it to the email address registered with Dropbox to allow the lookup of previously saved OAuth tokens.
 
@@ -47,9 +50,9 @@ If you want to access folders that are shared with you through Dropbox you have 
 
 ### Search
 
-```{attention}
+:::{attention}
 This only applies to Cyberduck.
-```
+:::
 
 You can [search recursively](../cyberduck/browser.md#filter-and-search) for files fast without browsing folders first.
 
@@ -61,9 +64,9 @@ A list of file versions can be viewed in the *Versions* tab of the *[Info](../cy
 
 You can share an URL to provide access to a document in your Dropbox from *File → Share…*. Optionally set a password required to download the file. Request others to add files to your Dropbox with *File → Request Files…*.
 
-```{note}
+:::{note}
 Password protected share links are only available for [paid business plans](https://help.dropbox.com/share/set-link-permissions).
-```
+:::
 
 ## Known Limitations
 
@@ -81,9 +84,9 @@ The modification date retention is supported for new files uploaded but without 
 
 Downloads may fail with a `409 Conflict (restricted_content)` error reply for files considered restricted.
 
-```{attention}
+:::{attention}
 The file cannot be transferred because the content is restricted. For example, sometimes there are legal restrictions due to copyright claims.
-```
+:::
 
 ### Will not Save the File or Folder Because of its Name.
 

--- a/protocols/dropbox.md
+++ b/protocols/dropbox.md
@@ -16,11 +16,11 @@ Access your [Dropbox](https://db.tt/49NiK95I) without syncing to your computer. 
 
 ![Dropbox Link](_images/Dropbox_Link.png)
 
-3. Log in to Dropbox and grant permissions to *Cyberduck*.
+2. Log in to Dropbox and grant permissions to *Cyberduck*.
 
 ![Dropbox Permissions](_images/Dropbox_Permissions.png)
 
-4. The authorization code will be submitted to Cyberduck automatically.
+3. The authorization code will be submitted to Cyberduck automatically.
 
 :::{admonition} Multiple Accounts
 :class: tip

--- a/protocols/ftp.md
+++ b/protocols/ftp.md
@@ -1,23 +1,23 @@
 FTP & FTP-TLS
 ====
 
-```{image} _images/ftp.png
+:::{image} _images/ftp.png
 :alt: FTP Drive Icon
 :width: 128px
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Providers
 
 Settings are specific to service providers. Use the provided [connection profiles](index.md#connection-profiles).
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - [SFTP To Go](sftp/sftptogo.md) - FTP with explicit TLS
 
@@ -35,10 +35,11 @@ FTP with [explicit](http://en.wikipedia.org/wiki/FTPS.md#explicit) TLS is suppor
 
 :::{admonition} TLSv1 and TLSv1.1 deprecation
 :class: warning
+
 TLSv1 and TLSv1.1 are no longer supported as of
 * Cyberduck [8.1.0](https://github.com/iterate-ch/cyberduck/milestone/184) or later
 * Mountain Duck [4.9.0](https://mountainduck.io/changelog/) or later
-  :::
+:::
 
 ### Mutual TLS
 
@@ -82,23 +83,22 @@ Connected to a FTP server this allows to send arbitrary command not available th
 
 Example configuration:
 
-	TLSOptions
-
-      The NoSessionReuseRequired option has been added.  As of
-      ProFTPD 1.3.3rc1, mod_tls only accepts SSL/TLS data connections
-      that reuse the SSL session of the control connection, as a security
-      measure.  Unfortunately, there are some clients (e.g. curl) which
-      do not reuse SSL sessions.
-
-      To relax the requirement that the SSL session from the control
-      connection be reused for data connections, use the following in the
-      proftpd.conf:
-
-        <IfModule mod_tls.c>
-          ...
-          TLSOptions NoSessionReuseRequired
-          ...
-        </IfModule>
+```
+TLSOptions
+     The NoSessionReuseRequired option has been added.  As of
+     ProFTPD 1.3.3rc1, mod_tls only accepts SSL/TLS data connections
+     that reuse the SSL session of the control connection, as a security
+     measure.  Unfortunately, there are some clients (e.g. curl) which
+     do not reuse SSL sessions.
+     To relax the requirement that the SSL session from the control
+     connection be reused for data connections, use the following in the
+     proftpd.conf:
+       <IfModule mod_tls.c>
+         ...
+         TLSOptions NoSessionReuseRequired
+         ...
+       </IfModule>
+```
 
 - The option `TLSOptions AllowClientRenegotiations` must be set for FTP-TLS connections (Issue [#3012](https://github.com/iterate-ch/cyberduck/issues/3012)).
 - The option `TLSProtocol SSLv23` must be set for FTP-TLS connections (Issue [#5061](https://github.com/iterate-ch/cyberduck/issues/5061)).
@@ -159,15 +159,21 @@ Various options are available to adjust the usage of different directory listing
 
 To disable `STAT` for directory listings, change the [hidden configuration option](../cyberduck/preferences.md#hidden-configuration-options) as follows:
 
-	defaults write ch.sudo.cyberduck ftp.command.stat false
+```
+defaults write ch.sudo.cyberduck ftp.command.stat false
+```
 
 To disable `LIST -a` for directory listings, open a Terminal.app window and enter
 
-	defaults write ch.sudo.cyberduck ftp.command.lista false
+```
+defaults write ch.sudo.cyberduck ftp.command.lista false
+```
 
 To disable `MLSD` for directory listings, open a Terminal.app window and enter
 
-	defaults write ch.sudo.cyberduck ftp.command.mlsd false
+```
+defaults write ch.sudo.cyberduck ftp.command.mlsd false
+```
 
 Restart Cyberduck.
 
@@ -175,9 +181,9 @@ Alternatively, you can use one of the connection profiles below for which the me
 * {download}`Download<https://profiles.cyberduck.io/FTP%20(Compatibility%20Mode).cyberduckprofile>` the *FTP (Compatibility Mode) Connection Profile* or install it from *Preferences… → Profiles* for preconfigured settings.
 * {download}`Download<https://profiles.cyberduck.io/FTP-SSL%20(Compatibility%20Mode).cyberduckprofile>` the *FTP-SSL (Compatibility Mode) Connection Profile* or install it from *Preferences… → Profiles* for preconfigured settings.
 
-```{note}
+:::{note}
 Connection profiles are available through the *Preferences → Profiles* tab.
-```
+:::
 
 #### Interoperability with ASUS Routers
 

--- a/protocols/googlecloudstorage.md
+++ b/protocols/googlecloudstorage.md
@@ -1,17 +1,17 @@
 Google Cloud Storage
 ====
 
-```{image} _images/googlestorage.png
+:::{image} _images/googlestorage.png
 :alt: Google Cloud Storage Drive Icon
 :width: 128px
-```
+:::
 
 > [Google Cloud Storage](https://cloud.google.com/storage/docs) is an S3 compatible service with pricing based on usage. Google Cloud Storage is interoperable with [S3](s3/index.md).
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Connecting
 
@@ -25,9 +25,9 @@ In the login prompt of Cyberduck you enter the *Access Key* for the username and
 
 ### OAuth 2.0 Access
 
-```{attention}
+:::{attention}
 Using prior versions to 4.12.0 (Mountain Duck) or 8.4.0 (Cyberduck), you might **not** be able to connect to Google Cloud Storage anymore because of the deprescated OAuth out-of-band flow.
-```
+:::
 
 You must obtain the project ID (`x-goog-project-id`) of your project from the Google Cloud Platform under *Storage Access* from the Google Cloud Storage tab. [Direct link to Google Cloud Storage settings.](https://console.cloud.google.com/storage/settings)
 
@@ -35,9 +35,9 @@ You must obtain the project ID (`x-goog-project-id`) of your project from the Go
 
 In the login prompt of Cyberduck, you enter the `x-goog-project-id` for the username. The authorization code will be submitted to Cyberduck automatically. You access the page with the authorization code from the link displayed in the login prompt. Click it to open it in a web browser window. You only need to get the authorization code from the website on the first login attempt. Subsequent OAuth authentications will use a refresh token retrieved from the service.
 
-```{attention}
+:::{attention}
 Using *[Advanced Protection Program](https://support.google.com/accounts/answer/7539956#non-goog_apps&zippy=%2Ccan-i-use-non-google-apps-services-or-apps-script-with-advanced-protection)* will cause the OAuth login flow to fail. 
-```
+:::
 
 #### Reset OAuth Tokens
 
@@ -53,7 +53,9 @@ You can register a [custom OAuth 2.0 client ID](profiles/google_client_id.md) wi
 
 You can list all buckets with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --username <projectid> --list gs:/`
+```
+duck --username <projectid> --list gs:/`
+```
 
 Refer to the [Cyberduck CLI](../cli/index.md) documentation for more operations.
 
@@ -79,11 +81,10 @@ You can set the default [storage class](https://cloud.google.com/storage/docs/st
 
 When this option is enabled in the *Google Cloud Storage* panel of the Info (*File → Info (macOS `⌘I` Windows `Alt+Return`)*) window for a bucket or any file within, available log records for this bucket are periodically aggregated into log files and delivered to root in the target logging bucket specified. It is considered best practice to choose a logging target that is different from the origin bucket.
 
-
-```{image} _images/GCS_tab_info_macOS.png
+:::{image} _images/GCS_tab_info_macOS.png
 :alt: Google Cloud Storage
 :width: 500px
-```
+:::
 
 ## Folders
 
@@ -103,9 +104,9 @@ Modification dates are supported through the `Custom-Time` metadata parameter. T
 
 A list of file versions can be viewed in the *Versions* tab of the *[Info](../cyberduck/info.md#versions)* window. Files can be reverted to a chosen version of this list. Additionally, versions of the list can be deleted.
 
-```{note}
+:::{note}
 `Bucket Versioning` has to be enabled within the *Google Storage* tab of the *Info* window before the versions of the files are displayed.
-```
+:::
 
 ## ACLs
 

--- a/protocols/googledrive.md
+++ b/protocols/googledrive.md
@@ -1,14 +1,14 @@
 Google Drive
 ====
 
-```{image} _images/googledrive.png
+:::{image} _images/googledrive.png
 :alt: Google Drive Icon
 :width: 128px
-```
+:::
 
-```{tip}
+:::{tip}
 Download [Mountain Duck](https://mountainduck.io/) as an alternative to *Drive File Stream* or *Drive for Desktop*.
-```
+:::
 
 ## Connecting
 
@@ -16,17 +16,17 @@ Connect to your [Google Drive](http://drive.google.com/) to store plain files.
 
 ### Authentication
 
-```{attention}
+:::{attention}
 Using prior versions to 4.12.0 (Mountain Duck) or 8.4.0 (Cyberduck), you might **not** be able to connect to Google Drive anymore because of the deprescated OAuth out-of-band flow.
-```
+:::
 
 Google Drive uses OAuth 2 to allow Cyberduck to access your files on Google Drive. Choose your account email as the username in the bookmark and choose *Allow* on the website opened in your default web browser to allow Cyberduck to *View and manage the files in your Google Drive*. The authorization code will be submitted to Cyberduck automatically. Subsequent connections will not require authorization, unless the refresh token itself is expired due to inactivity.
 
-```{admonition} Advanced Protection Program
+:::{admonition} Advanced Protection Program
 :class: warning
 
 Using *[Advanced Protection Program](https://support.google.com/accounts/answer/7539956#non-goog_apps&zippy=%2Ccan-i-use-non-google-apps-services-or-apps-script-with-advanced-protection)* will cause the OAuth login flow to fail with the error message: `400 admin_policy_enforced`.
-```
+:::
 
 ### Google Apps Accounts
 
@@ -36,10 +36,11 @@ To access the Google Docs storage of your company's [Google Apps](https://worksp
 
 Refer to [Signing in using application-specific passwords](http://support.google.com/accounts/bin/answer.py?answer=185833) on how to set an application-specific password to access Google Drive with 2-step verification enabled for your Google Account.
 
-```{admonition} Multiple Accounts
+:::{admonition} Multiple Accounts
 :class: tip
+
 You can connect to multiple accounts at the same time. Create a new bookmark for every account and run through the OAuth flow. Make sure to log out in your browser prior setting up a new bookmark to make sure the new bookmark is linked to a newly authenticated account.
-```
+:::
 
 ### Reset OAuth Tokens
 
@@ -54,11 +55,14 @@ You can register a [custom OAuth 2.0 client ID](profiles/google_client_id.md) wi
 ## Cyberduck CLI
 You can list the root contents of your Google Drive with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --list googledrive:/
+```
+duck --list googledrive:/
+```
 
 Refer to the [Cyberduck CLI](../cli/index.md) documentation for more operations. For subsequent invocations make sure to include the `--username` parameter and set it to the email address registered with Google to allow the lookup of previously saved OAuth tokens.
 
 ## Features
+
 ### Search
 
 You can [search recursively](../cyberduck/browser.md#filter-and-search) for files fast without browsing folders first.
@@ -71,7 +75,9 @@ A list of file versions can be viewed in the *Versions* tab of the *[Info](../cy
 
 Deleted files are trashed instead of being permanently deleted. This feature is enabled by default. It can be disabled using a [hidden configuration option](../cyberduck/preferences.md#hidden-configuration-options).
 
-	browser.delete.trash=false
+```
+browser.delete.trash=false
+```
 
 ### Documents
 
@@ -82,9 +88,9 @@ For Google Docs documents (*Docs, Sheets, Slides*), URL shortcut files are displ
 - `.webloc` on macOS
 - `.url` on Windows
 
-```{attention}
+:::{attention}
 *Google Docs* files can't be managed (renamed, moved, or deleted) within Mountain Duck or Cyberduck. 
-```
+:::
 
 #### Team Drives
 
@@ -105,6 +111,7 @@ Create download [shares](../cyberduck/share.md#google-drive) of files or folders
 Google Drive is imposing rate limits to requests resulting in `403 Forbidden` replies indicating the *Rate Limit Exceeded* error. Make sure you have set to *Repeat failed networking tasks* in [Preferences → Connection](../cyberduck/connection.md#repeat-failed-networking-tasks) and set a delay.
 
 ### Top Level folder
+
 It is not possible to create a top level folder in Mountain Duck or Cyberduck. Instead, the following virtual top level folders are displayed which cannot be moved or renamed:
 
 | Folder Name    |         Contents         |

--- a/protocols/index.md
+++ b/protocols/index.md
@@ -29,83 +29,83 @@ spectra
 
 All major server and cloud storage protocols are supported to connect to just about any server or cloud storage. Support for the listed protocols and [connection profiles](profiles/index.md) is available in [Cyberduck](../cyberduck/index.md), [Cyberduck CLI](../cli/index.md) and [Mountain Duck](../mountainduck/index.md).
 
-### [FTP](ftp.md)
+## [FTP](ftp.md)
 
 With support for secure TLS connections and custom origin [Amazon CloudFront (Content Delivery Network) distribution](../protocols/cdn/cloudfront) option.
 
-### [Amazon S3](s3/index.md)
+## [Amazon S3](s3/index.md)
 
 Transfer files to your S3 account and browse the S3 buckets and files in a hierarchical way. Supports Amazon Web Services (AWS) and many third party providers.
 
 - [S3 providers](s3/index.md#third-party-providers)
 
-### [Google Cloud Storage](googlecloudstorage.md)
+## [Google Cloud Storage](googlecloudstorage.md)
 
 Transfer files to your Google Storage account and browse files, manage ACLs and bucket configurations.
 
-### [Backblaze B2](b2.md)
+## [Backblaze B2](b2.md)
 
 Backblaze B2 Cloud Storage is ¼ of the price of Amazon S3
 
-### [WebDAV](webdav/index.md)
+## [WebDAV](webdav/index.md)
 
 Connect to any WebDAV compliant server using both HTTP and HTTP/SSL and custom origin [Amazon CloudFront (Content Delivery Network) distribution](cdn/cloudfront.md) option.
 
 - [WebDAV providers](webdav/index.md#providers)
 
-### [SSH/SFTP](sftp/index.md)
+## [SSH/SFTP](sftp/index.md)
 
 Advanced configuration for SSH connections using public key authentication and custom origin [Amazon CloudFront (Content Delivery Network) distribution](cdn/cloudfront.md) option.
 
-### [SMB](smb.md)
+## [SMB](smb.md)
 
 SMB (Server Message Block) is used to access Windows File Shares.
 
-### [OpenStack Object Storage](openstack/index.md)
+## [OpenStack Object Storage](openstack/index.md)
 
 Connect to cloud storage providers using OpenStack Swift for the storage protocol. Includes support for [Rackspace Cloud Files](openstack/cloudfiles).
 
 - [OpenStack Providers](openstack/index.md#third-party-providers)
 
-### [Windows Azure](azure.md)
+## [Windows Azure](azure.md)
 
 Massively scalable object storage for unstructured data.
 
-### [Microsoft OneDrive](onedrive.md)
+## [Microsoft OneDrive](onedrive.md)
 
 Access OneDrive without syncing to your computer.
 
-### [Microsoft SharePoint](sharepoint.md)
+## [Microsoft SharePoint](sharepoint.md)
 
 Connect to SharePoint Server and SharePoint Online.
 
-### [Google Drive](googledrive.md)
+## [Google Drive](googledrive.md)
 
 Access all your documents and upload files of any type to use your Google Drive account for storage.
 
-### [Box](box.md)
+## [Box](box.md)
 
 Simple, secure file sharing and collaboration from anywhere.
 
-### [Dropbox](dropbox.md)
+## [Dropbox](dropbox.md)
 
 Access Dropbox without syncing to your computer.
 
-### [DRACOON](dracoon.md)
+## [DRACOON](dracoon.md)
 
 A highly secure, platform-independent enterprise filesharing solution
 
-### [Files.com](files.com.md)
+## [Files.com](files.com.md)
 
 Files.com is Smart Cloud Storage for modern teams
 
-### [iRODS](irods.md)
+## [iRODS](irods.md)
 
 The Integrated Rule-Oriented Data System (iRODS) is an open source data management software used by research organizations and government agencies worldwide.
 
-### [Spectra BlackPearl Deep Storage Gateway](spectra.md)
+## [Spectra BlackPearl Deep Storage Gateway](spectra.md)
 
-### Local Disk
+## Local Disk
 Open a window to browse your local hard disk to drag files for download or upload to a remote server from within the application. You can browse [Cryptomator Vaults](../cryptomator/index.md#access-vaults-on-local-disk) stored on your computer.
 
 :::{warning}

--- a/protocols/index.md
+++ b/protocols/index.md
@@ -1,7 +1,7 @@
 Protocols
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 profiles/index
@@ -25,14 +25,16 @@ files.com
 dracoon
 irods
 spectra
-```
+:::
 
 All major server and cloud storage protocols are supported to connect to just about any server or cloud storage. Support for the listed protocols and [connection profiles](profiles/index.md) is available in [Cyberduck](../cyberduck/index.md), [Cyberduck CLI](../cli/index.md) and [Mountain Duck](../mountainduck/index.md).
 
 ### [FTP](ftp.md)
+
 With support for secure TLS connections and custom origin [Amazon CloudFront (Content Delivery Network) distribution](../protocols/cdn/cloudfront) option.
 
 ### [Amazon S3](s3/index.md)
+
 Transfer files to your S3 account and browse the S3 buckets and files in a hierarchical way. Supports Amazon Web Services (AWS) and many third party providers.
 
 - [S3 providers](s3/index.md#third-party-providers)
@@ -42,49 +44,63 @@ Transfer files to your S3 account and browse the S3 buckets and files in a hiera
 Transfer files to your Google Storage account and browse files, manage ACLs and bucket configurations.
 
 ### [Backblaze B2](b2.md)
+
 Backblaze B2 Cloud Storage is ¼ of the price of Amazon S3
 
 ### [WebDAV](webdav/index.md)
+
 Connect to any WebDAV compliant server using both HTTP and HTTP/SSL and custom origin [Amazon CloudFront (Content Delivery Network) distribution](cdn/cloudfront.md) option.
 
 - [WebDAV providers](webdav/index.md#providers)
 
 ### [SSH/SFTP](sftp/index.md)
+
 Advanced configuration for SSH connections using public key authentication and custom origin [Amazon CloudFront (Content Delivery Network) distribution](cdn/cloudfront.md) option.
 
 ### [SMB](smb.md)
+
 SMB (Server Message Block) is used to access Windows File Shares.
 
 ### [OpenStack Object Storage](openstack/index.md)
+
 Connect to cloud storage providers using OpenStack Swift for the storage protocol. Includes support for [Rackspace Cloud Files](openstack/cloudfiles).
 
 - [OpenStack Providers](openstack/index.md#third-party-providers)
 
 ### [Windows Azure](azure.md)
+
 Massively scalable object storage for unstructured data.
 
 ### [Microsoft OneDrive](onedrive.md)
+
 Access OneDrive without syncing to your computer.
 
 ### [Microsoft SharePoint](sharepoint.md)
+
 Connect to SharePoint Server and SharePoint Online.
 
 ### [Google Drive](googledrive.md)
+
 Access all your documents and upload files of any type to use your Google Drive account for storage.
 
 ### [Box](box.md)
+
 Simple, secure file sharing and collaboration from anywhere.
 
 ### [Dropbox](dropbox.md)
+
 Access Dropbox without syncing to your computer.
 
 ### [DRACOON](dracoon.md)
+
 A highly secure, platform-independent enterprise filesharing solution
 
 ### [Files.com](files.com.md)
+
 Files.com is Smart Cloud Storage for modern teams
 
 ### [iRODS](irods.md)
+
 The Integrated Rule-Oriented Data System (iRODS) is an open source data management software used by research organizations and government agencies worldwide.
 
 ### [Spectra BlackPearl Deep Storage Gateway](spectra.md)
@@ -92,9 +108,9 @@ The Integrated Rule-Oriented Data System (iRODS) is an open source data manageme
 ### Local Disk
 Open a window to browse your local hard disk to drag files for download or upload to a remote server from within the application. You can browse [Cryptomator Vaults](../cryptomator/index.md#access-vaults-on-local-disk) stored on your computer.
 
-```{warning}
+:::{warning}
 If folder contents are not shown, make sure to grant access from Mountain Duck in *System Settings → Privacy & Security → Files and Folders*.
-```
+:::
 
 ## Connection Profiles
 
@@ -104,36 +120,38 @@ If folder contents are not shown, make sure to grant access from Mountain Duck i
 
 Select connection protocols in _Preferences → Profiles_ to be installed in addition to the default protocols listed below. Either scroll through the list or use the search function to look for a specific profile. The connection profile will be installed after enabling the corresponding checkbox. To disable a connection profile simply uncheck the checkbox. The profile will be disabled after closing the application.
 
-`````{tabs}
-````{group-tab} macOS
+:::::{tabs}
+::::{group-tab} macOS
 
-```{image} _images/Preferences_Profiles_macOS.png
+:::{image} _images/Preferences_Profiles_macOS.png
 :alt: macOS
 :width: 600px
-```
+:::
 
-````
-````{group-tab} Windows
+::::
+::::{group-tab} Windows
 
-```{image} _images/Preferences_Profiles.png
+:::{image} _images/Preferences_Profiles.png
 :alt: Windows
 :width: 500px
-```
-````
-`````
+:::
 
-```{note}
+::::
+:::::
+
+:::{note}
 You cannot disable default protocols or connection profiles currently in use in any bookmark.
-```
+:::
 
 ## Features
 ### Modification Date
 Retaining the modification date for files uploaded is not supported for all protocols.
 
-```{admonition} Mountain Duck
+:::{admonition} Mountain Duck
 :class: attention
+
 Protocols with limited support for modification dates only allow to set the modification for new files uploaded but not changing it later.
-```
+:::
 
 | Protocol             | Native Support | Limited Support |
 |----------------------| :---: | :---: |
@@ -156,8 +174,9 @@ Protocols with limited support for modification dates only allow to set the modi
 | Windows Azure        | ❌ | ❌ |
 | OpenStack Object Storage        | ❌ | ❌ |
 
-```{admonition} Interoperability
+:::{admonition} Interoperability
 :class: attention
+
 - **WebDAV**: Saving the modification dates requires support from server storing metadata in custom namespace
 - **FTP**: Requires support from server for `MFMT` or `UTIME` extensions
-```
+:::

--- a/protocols/irods.md
+++ b/protocols/irods.md
@@ -3,21 +3,22 @@ iRODS (Integrated Rule-Oriented Data System)
 
 > The Integrated Rule-Oriented Data System (iRODS) is an open-source data management software used by research organizations and government agencies worldwide.
 
-```{admonition} iRODS ...
+:::{admonition} iRODS ...
 :class: tip
+
 - ... enables data discovery using a metadata catalog that describes every file, every directory, and every storage resource in the data grid.
 - ... automates data workflows, with a rule engine that permits any action to be initiated by any trigger on any server or client in the grid.
 - ... enables secure collaboration, so users only need to log in to their home grid to access data hosted on a remote grid.
 - ... implement data virtualization, allowing access to distributed storage assets under a unified namespace, and freeing organizations from getting locked into single-vendor storage solutions.
-```
+:::
 
 ## Connecting
 
 Download the corresponding *Connection Profile* for preconfigured settings and double-click on it to install it. Choose the profile from the list of protocols when editing a [bookmark](../cyberduck/bookmarks.md) or use the `<vendor>:/` scheme when using the [CLI](../cli/index).
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### Provider
 
@@ -35,15 +36,19 @@ This is the default with no additional configuration required.
 
 To authenticate with PAM, prefix the username with PAM:or set it in the [connection profile](index.md#connection-profiles) using as
 
-    <key>Authorization</key>
-    <string>PAM</string>
+```
+      <key>Authorization</key>
+      <string>PAM</string>
+```
 
 ### Resource Server
 
 You can specify a non-default resource server in the Region key of the [connection profile](index.md#connection-profiles) using a colon-separated syntax (Issue [#8721](https://github.com/iterate-ch/cyberduck/issues/8721)) such as
 
-	<key>Region</key>
-	<string>iplant:storageresourcename</string>
+```
+   	<key>Region</key>
+   	<string>iplant:storageresourcename</string>
+```
 
 ## Transfers
 

--- a/protocols/onedrive.md
+++ b/protocols/onedrive.md
@@ -1,14 +1,14 @@
 Microsoft OneDrive
 ====
 
-```{image} _images/onedrive.png
+:::{image} _images/onedrive.png
 :alt: Microsoft OneDrive
 :width: 128px
-```
+:::
 
-```{tip}
+:::{tip}
 Download [Mountain Duck](https://mountainduck.io/) as an alternative to the *One Drive* client from Microsoft.
-```
+:::
 
 ## Connecting
 
@@ -22,11 +22,11 @@ The OneDrive connection profile is bundled by default and connects to the endpoi
 
 - The authorization code will be submitted to Cyberduck automatically. Subsequent connections will not require authorization, unless the refresh token itself is expired due to inactivity.
 
-
-```{admonition} Multiple Accounts
+:::{admonition} Multiple Accounts
 :class: tip
+
 You can connect to multiple accounts at the same time. Create a new bookmark for every account and run through the OAuth flow. Make sure to log out of any account in web browser before triggering the OAuth flow for a new account.
-```
+:::
 
 ### Reset OAuth Tokens
 
@@ -52,9 +52,9 @@ Depending on the setup of your AAD you may need to perform several steps in orde
 
 #### Manually Adding Cyberduck & Mountain Duck
 
-```{Important}
+:::{Important}
 Cyberduck 7.8 and later or Mountain Duck 4.4 and later required
-```
+:::
 
 Copy the link that corresponds to your used version, and send it to your domain administrator, this will add Cyberduck to the domain and all users are allowed to access Cyberduck in the future.
 
@@ -72,11 +72,14 @@ There is a preview method of review application consent through the AAD Portal. 
 
 You can list the root contents of your OneDrive with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --list onedrive:/
+```
+duck --list onedrive:/
+```
 
 Refer to the [Cyberduck CLI](../cli/index.md) documentation for more operations. For subsequent invocations make sure to include the `--username` parameter and set it to the email address registered with Microsoft to allow the lookup of previously saved OAuth tokens.
 
 ## Features
+
 ### Search
 
 You can [search recursively](../cyberduck/browser.md#filter-and-search) for files fast without browsing folders first.
@@ -99,6 +102,7 @@ There are some limitations that you should keep in mind while working with.
 - OneDrive API does not list pending upload sessions therefore resuming uploads in Cyberduck will cause the upload to start all over again.
 
 ### Top Level folder
+
 It is not possible to create a top level folder in Mountain Duck or Cyberduck. Instead, the following virtual top level folders are displayed which cannot be moved or renamed:
 
 | Folder Name |    Contents    |
@@ -107,4 +111,5 @@ It is not possible to create a top level folder in Mountain Duck or Cyberduck. I
 | Shared      | Shared folders |
 
 ### Quota
+
 Mountain Duck can only display the correct cloud storage quota as remaining disk space when setting the *Path* in the bookmark configuration to a folder different from `/`, for example `My Files`.

--- a/protocols/openstack/auro.md
+++ b/protocols/openstack/auro.md
@@ -1,10 +1,10 @@
 AURO
 ====
 
-```{image} _images/Auro_Logo.jpg
+:::{image} _images/Auro_Logo.jpg
 :alt: AURO Logo
 :height: 128px
-```
+:::
 
 > AURO is 100% Canadian owned and operated provider of public cloud infrastructure based on OpenStack.
 

--- a/protocols/openstack/clouda.md
+++ b/protocols/openstack/clouda.md
@@ -1,10 +1,10 @@
 Cloud A
 ====
 
-```{image} _images/cropped-cloudA_transparent_temp_oldsite1.png
+:::{image} _images/cropped-cloudA_transparent_temp_oldsite1.png
 :alt: Cloud A Logo
 :height: 128px
-```
+:::
 
 > [Cloud-A](https://www.clouda.ca/cloud-infrastructure#cloud_servers) is a leading provider of public cloud Infrastructure based in Canada. Our products automate & simplify the installation and management of the hardware and software that provides the infrastructure for large-scale environments having hundreds or thousands of servers supporting high-performance compute applications.
 

--- a/protocols/openstack/cloudfiles.md
+++ b/protocols/openstack/cloudfiles.md
@@ -9,9 +9,9 @@ Rackspace Cloud Files
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### Connection Profiles
 
@@ -58,9 +58,9 @@ You can enable private container access logging to `.ACCESS_LOGS` by adding the 
 
 You can access all URLs (including from [CDN](../../protocols/cdn/akamai.md) configurations) from the menu Edit → Copy URL and File → Open URL. 
 
-```{note}
+:::{note}
 You must first open *File → Info → Distribution (CDN)* before these URLs are available.
-```
+:::
 
 ![Copy URLs](_images/Copy_URLs.png)
 
@@ -76,4 +76,6 @@ You can add [custom HTTP headers](../../cyberduck/info.md#metadata-http-headers)
 
 Currently only possible using a [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) you can define default headers to be added for uploads. Multiple headers must be separated using a whitespace delimiter. Key and value of a header are separated with `=`. For example, if you want to add a HTTP header for Cache-Control and one named `Creator` you would set
 
-	defaults write ch.sudo.cyberduck openstack.metadata.default "Cache-Control=public,max-age=86400 Creator=Cyberduck"
+```
+defaults write ch.sudo.cyberduck openstack.metadata.default "Cache-Control=public,max-age=86400 Creator=Cyberduck"
+```

--- a/protocols/openstack/index.md
+++ b/protocols/openstack/index.md
@@ -1,7 +1,7 @@
 Swift (OpenStack Object Storage)
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 auro
@@ -19,25 +19,25 @@ ovh
 selectel
 swiftstack
 zetta.io
-```
+:::
 
-```{image} _images/swift.png
+:::{image} _images/swift.png
 :alt: Swift Drive Icon
 :width: 128px
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Connecting
 
 Connect to a [Swift (OpenStack Object Storage)](https://docs.openstack.org/swift/latest/) installation. Choose *Swift (OpenStack Object Storage)* from the list of protocols.
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### Authentication Context Path
 
@@ -92,7 +92,9 @@ On your first login, you will need to create at least one container (folder) to 
 
 Connect with [Cyberduck CLI](https://duck.sh/) using the default connection profile using authentication with `Keystone 2.0` for context `/v2.0/tokens` with
 
-	duck --username OS_TENANT_ID:OS_USERNAME --password PASSWORD  --list swift://SWIFT_KEYSTONE_AUTH_SERVER/CONTAINERNAME
+```
+duck --username OS_TENANT_ID:OS_USERNAME --password PASSWORD  --list swift://SWIFT_KEYSTONE_AUTH_SERVER/CONTAINERNAME
+```
 
 Refer to the [Cyberduck CLI](../../cli/index.md) documentation for more operations.
 

--- a/protocols/openstack/infomaniak.md
+++ b/protocols/openstack/infomaniak.md
@@ -3,10 +3,10 @@ Infomaniak
 
 ![Infomaniak Drive Icon](_images/blue-128.png)
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Infomaniak Public Cloud
 
@@ -14,9 +14,9 @@ Infomaniak
 
 ### Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 #### Connection Profiles
 
@@ -32,6 +32,7 @@ Enter the following information in the [bookmark](../../cyberduck/bookmarks.md):
 - Password: `password is the same as the one you use for the OpenStack dashboard`
 
 ### References
+
 - [Official Infomaniak Public Cloud documentation](https://docs.infomaniak.cloud)
 - [Find out more about Infomaniak Public Cloud](https://www.infomaniak.com/en/hosting/public-cloud)
 - [Test Infomaniak Public Cloud with free tiers](https://www.infomaniak.com/en/hosting/public-cloud)
@@ -44,9 +45,9 @@ Swiss Backup is a solution that automatically backs up your files, workstations,
 
 ### Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 #### Connection Profiles
 
@@ -64,6 +65,7 @@ Enter the following information in the [bookmark](../../cyberduck/bookmarks.md):
 - Password: `password sent by email when you created your Swiss Backup space`
 
 ### References
+
 - [Official Infomaniak documentation](https://www.infomaniak.com/en/support/faq/2284/startup-guide-swiss-backup)
 - [Cyberduck connection profile documentation](https://www.infomaniak.com/en/support/faq/2282/swiss-backup-backing-up-files-with-cyberduck)
 - [Find out more about Swiss Backup](https://www.infomaniak.com/en/swiss-backup)

--- a/protocols/openstack/memset.md
+++ b/protocols/openstack/memset.md
@@ -10,9 +10,9 @@ Sign up for a free account that comes with 5GB of storage and 5GB of transfer pe
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### Connection Profile
 
@@ -40,7 +40,6 @@ Enter the following information in the [bookmark](../../cyberduck/bookmarks.md):
 - Password: `Memstore password (API key)`
 
 ![Memstore configuration](_images/Memstore.Swift.Config.png)
-
 
 ## References
 - [Documentation and Resources for Developers](https://docs.memset.com/cd/API-%2F-Developer-Resources.199072028.html)

--- a/protocols/openstack/ovh.md
+++ b/protocols/openstack/ovh.md
@@ -3,15 +3,15 @@ OVH Public Cloud Storage
 
 > With the [OVH Object Storage](https://www.ovh.com/us/public-cloud/storage/object-storage/) cloud solution, you only pay for what you use with no limitation when it comes to size and duration. Thanks to the OpenStack Swift technology, you can store your high-performance data in the OVH cloud environment and instantly access it at any time. This solution is perfect for web projects and can be used to make your objects available through HTTP.
 
-```{seealso}
+:::{seealso}
 [hubiC (OVH)](hubic)
-```
+:::
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### OpenStack Swift
 
@@ -48,11 +48,15 @@ Access your containers via S3 by creating an S3 user via *OVHcloud Control Panel
 
 To use a connection, the corresponding profile must be [installed](../../cli/index.md#profiles) with the following parameters using [Cyberduck CLI](https://duck.sh/).
 
-	duck --username OS_TENANT_ID:OS_USERNAME --password PROJECT_USER_PASSWORD --region BHS3 --list ovh://CONTAINERNAME
+```
+duck --username OS_TENANT_ID:OS_USERNAME --password PROJECT_USER_PASSWORD --region BHS3 --list ovh://CONTAINERNAME
+```
 
 Alternatively, connect using the default connection profile by specifying the authentication hostname with
 
-	duck --username OS_TENANT_ID:OS_USERNAME --password PROJECT_USER_PASSWORD --region BHS3 --list swift://auth.cloud.ovh.net/CONTAINERNAME
+```
+duck --username OS_TENANT_ID:OS_USERNAME --password PROJECT_USER_PASSWORD --region BHS3 --list swift://auth.cloud.ovh.net/CONTAINERNAME
+```
 
 ## Containers
 
@@ -66,6 +70,7 @@ You can choose the region when creating a new container with *File → New Folde
 - Server-side encrypted objects using SSE-C can't be used or downloaded.
 
 ## References
+
 - [Manage Object Storage with Cyberduck](https://docs.ovh.com/us/en/storage/manage_object_storage_with_cyberduck/)
 - [Configure user access to Horizon](https://docs.ovh.com/us/en/public-cloud/configure_user_access_to_horizon/)
 - [Configure S3 access](https://support.us.ovhcloud.com/hc/en-us/articles/10695902938899-How-to-Create-a-Container-in-OVHcloud-S3-Object-Storage)

--- a/protocols/openstack/selectel.md
+++ b/protocols/openstack/selectel.md
@@ -1,10 +1,10 @@
 Selectel Cloud Storage
 ====
 
-```{image} _images/selectel.png
+:::{image} _images/selectel.png
 :alt: Selectel Drive Icon
 :width: 128px
-```
+:::
 
 > [Selectel Cloud Storage](https://selectel.ru/en/services/cloud/storage/) is a durable solution for developers and businesses.
 

--- a/protocols/openstack/swiftstack.md
+++ b/protocols/openstack/swiftstack.md
@@ -9,9 +9,9 @@ SwiftStack
 
 ### Connection Profiles
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 Connect to a SwiftStack cluster via HTTP or HTTPS using these preconfigured [connection profiles](../../cyberduck/connection.md#connection-profiles):
 

--- a/protocols/profiles/aws_oidc.md
+++ b/protocols/profiles/aws_oidc.md
@@ -3,10 +3,10 @@ Custom connection profile using OpenID Connect provider and AssumeRoleWithWebIde
 
 > With web identity federation, you don't need to create custom sign-in code or manage your own user identities. Instead, users of your app can sign in using a well-known external identity provider (IdP), such as Login with Amazon, Facebook, Google, or any other OpenID Connect (OIDC)-compatible IdP. They can receive an authentication token, and then exchange that token for temporary security credentials in AWS that map to an IAM role with permissions to use the resources in your AWS account.
 
-```{important}
+:::{important}
 * Cyberduck [8.7.0](https://cyberduck.io/changelog/) or later required
 * Mountain Duck [4.15.0](https://mountainduck.io/changelog/) or later required
-```
+:::
 
 Connection profiles must include the `OAuth Authorization Url`, `OAuth Token Url`, `OAuth Redirect Url` and `Scopes` of the OpenID Connect (OIDC) identity provider and the `STS Endpoint` for the STS API endpoint which defaults to `https://sts.amazonaws.com/`. Set the property `s3.assumerole.rolearn` in the connection profile to the Role ARN configured in AWS. Set it to `s3.assumerole.rolearn=` for a prompt to enter on login.
 

--- a/protocols/profiles/google_client_id.md
+++ b/protocols/profiles/google_client_id.md
@@ -11,14 +11,15 @@ Follow the steps in [Setting up OAuth 2.0](https://support.google.com/googleapi/
 
 * Choose _Desktop app_ as the _Application type_ which will result in a Client ID with a suffix like `number-id.apps.googleusercontent.com`.
 
-```{image} _images/Google_Create_OAuth_Client_ID.png
+:::{image} _images/Google_Create_OAuth_Client_ID.png
 :alt: Google Create OAuth Client ID
 :width: 600px
-```
-```{image} _images/Google_Client_ID_and_client_secret.png
+:::
+
+:::{image} _images/Google_Client_ID_and_client_secret.png
 :alt: Google Client ID and Client Secret
 :width: 600px
-```
+:::
 
 * Edit the OAuth Consent Screen* to add the scopes *Google Cloud Storage JSON API* `../auth/devstorage.read_write` and/or *Google Drive API* `../auth/drive`. You will first need to enable *Google Drive* in the Google API Library.
 
@@ -31,8 +32,8 @@ Create a custom [connection profile](index.md) with the following properties.
 - `OAuth Redirect Url`. Use the reverse notation of the client id and set it like
 
 ```
-<key>OAuth Redirect Url</key>
-<string>com.googleusercontent.apps.number-id:oauth</string>
+        <key>OAuth Redirect Url</key>
+        <string>com.googleusercontent.apps.number-id:oauth</string>
 ```
 
 ### Sample Google Drive with Custom OAuth Client ID Connection Profile

--- a/protocols/profiles/index.md
+++ b/protocols/profiles/index.md
@@ -1,23 +1,23 @@
 Connection Profiles
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 google_client_id
 aws_oidc
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 [Connection profiles](../../cyberduck/connection.md#connection-profiles) (`.cyberduckprofile`) are documents describing connection settings for a hosting provider.
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - [Third-Party S3 providers](../s3/index.md#third-party-providers)
 - [OpenStack Providers](../openstack/index.md#third-party-providers)
@@ -28,25 +28,25 @@ Connection profiles can be activated by either installing the file by double-cli
 
 ## Contributing Connection Profiles
 
-```{admonition} Info
+:::{admonition} Info
 :class: tip
 
 To contribute new connection profiles, open a pull request in the [`iterate-ch/profiles` repository](https://github.com/iterate-ch/profiles). Once the pull request is approved the profile will be available through the _Preferences → Profiles_ tab in [Mountain Duck](../../mountainduck/preferences.md#profiles) and Cyberduck.
-```
+:::
 
 ### Technical File Format Specification
 
-```{note}
+:::{note}
 Connection profile files ([XML Property List Format](http://en.wikipedia.org/wiki/Property_list)) can be created for customers to make it easier to connect with a double-click on that file without entering the connection details manually. [Contact us](mailto:support@cyberduck.io) if you are a service provider and need assistance in setting this up.
-```
+:::
 
 The following properties can be defined in a connection profile:
 
 - `Protocol` *(Required)*
 - `Vendor` (Hosting Provider) *(Required)*
-```{important}
+:::{important}
 The value of `Vendor` must be unique among all installed connection profiles.
-```
+:::
 - `Description` *(Required)*
 - `Default Nickname` Prefilled bookmark name.
 - `Default Hostname` Prefilled server name.
@@ -56,9 +56,9 @@ The value of `Vendor` must be unique among all installed connection profiles.
 - `Port Configurable` Boolean if port number is configurable.
 - `Default Path`
 - `Schemes` Additional array of schemes this profile can be referenced with in [Cyberduck CLI](../../cli/index.md)
-```{note}
+:::{note}
 All additional schemes are registered as a scheme handler when opening [Mountain Duck](../../mountainduck/index.md). This allows to reference files and folders in a web application using a custom scheme like `customscheme:/(/<hostname>)/path` to open in Windows Explorer or Finder.
-```
+:::
 - `Username Configurable` Boolean if username is configurable.
 - `Username Placeholder` Suggestion for username in login credentials. Used for input field label when editing bookmark.
 - `Password Placeholder` Suggestion for password in login credentials. Used for input field label when editing bookmark.
@@ -154,25 +154,27 @@ All additional schemes are registered as a scheme handler when opening [Mountain
 Create a *multi-TIFF* containing the needed icon sizes:
 1. Create a high-resolution *.png* file based on the PSD template
 2. Use the following script to generate the different resolutions and the multi-TIFF *disk.tiff* file:
-    ```{code-block}
-    png=[LOCATION_OF_HIGH_RESOLUTION_PNG]
-    tmp=$TMPDIR
-    target=[TARGET_FOLDER]
-    /usr/bin/sips -s format png -z 128 128 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_64x64@2x.png
-    /usr/bin/sips -s format png -z 64 64 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_64x64.png
-    /usr/bin/sips -s format png -z 96 96 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_96@2x.png
-    /usr/bin/sips -s format png -z 48 48 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_96.png
-    /usr/bin/sips -s format png -z 256 256 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_256@2x.png
-    /usr/bin/sips -s format png -z 128 128 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_256.png
-    /usr/bin/tiffutil -cathidpicheck ${tmp}/icon_64x64@2x.png ${tmp}/icon_64x64.png ${tmp}/icon_96.png ${tmp}/icon_96@2x.png ${tmp}/icon_256.png ${tmp}/icon_256@2x.png -out ${target}/disk.tiff
-    ```
+```
+png=[LOCATION_OF_HIGH_RESOLUTION_PNG]
+tmp=$TMPDIR
+target=[TARGET_FOLDER]
+/usr/bin/sips -s format png -z 128 128 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_64x64@2x.png
+/usr/bin/sips -s format png -z 64 64 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_64x64.png
+/usr/bin/sips -s format png -z 96 96 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_96@2x.png
+/usr/bin/sips -s format png -z 48 48 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_96.png
+/usr/bin/sips -s format png -z 256 256 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_256@2x.png
+/usr/bin/sips -s format png -z 128 128 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_256.png
+/usr/bin/tiffutil -cathidpicheck ${tmp}/icon_64x64@2x.png ${tmp}/icon_64x64.png ${tmp}/icon_96.png ${tmp}/icon_96@2x.png ${tmp}/icon_256.png ${tmp}/icon_256@2x.png -out ${target}/disk.tiff
+```
 3. Use the command ``` base64 ./disk.tiff -b 70 ``` to generate the base64 version of the multi-TIFF file. This final version will be used for the connection profile.
 
 ## Sample Connection Profiles
 
 ### Google Custom OAuth Client ID
+
 - [Custom OAuth 2.0 Client ID for Google Cloud Storage and Google Drive](google_client_id.md).
 
 ### S3 and OpenID Connect Federation 
+
 Customization of connection profiles using OpenID Connect provider and AssumeRoleWithWebIdentity STS API
 - [Sample connection profiles for S3 and OpenID Connect Federation](aws_oidc.md)

--- a/protocols/profiles/index.md
+++ b/protocols/profiles/index.md
@@ -154,18 +154,18 @@ All additional schemes are registered as a scheme handler when opening [Mountain
 Create a *multi-TIFF* containing the needed icon sizes:
 1. Create a high-resolution *.png* file based on the PSD template
 2. Use the following script to generate the different resolutions and the multi-TIFF *disk.tiff* file:
-```
-png=[LOCATION_OF_HIGH_RESOLUTION_PNG]
-tmp=$TMPDIR
-target=[TARGET_FOLDER]
-/usr/bin/sips -s format png -z 128 128 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_64x64@2x.png
-/usr/bin/sips -s format png -z 64 64 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_64x64.png
-/usr/bin/sips -s format png -z 96 96 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_96@2x.png
-/usr/bin/sips -s format png -z 48 48 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_96.png
-/usr/bin/sips -s format png -z 256 256 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_256@2x.png
-/usr/bin/sips -s format png -z 128 128 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_256.png
-/usr/bin/tiffutil -cathidpicheck ${tmp}/icon_64x64@2x.png ${tmp}/icon_64x64.png ${tmp}/icon_96.png ${tmp}/icon_96@2x.png ${tmp}/icon_256.png ${tmp}/icon_256@2x.png -out ${target}/disk.tiff
-```
+  ```
+  png=[LOCATION_OF_HIGH_RESOLUTION_PNG]
+  tmp=$TMPDIR
+  target=[TARGET_FOLDER]
+  /usr/bin/sips -s format png -z 128 128 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_64x64@2x.png
+  /usr/bin/sips -s format png -z 64 64 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_64x64.png
+  /usr/bin/sips -s format png -z 96 96 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_96@2x.png
+  /usr/bin/sips -s format png -z 48 48 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_96.png
+  /usr/bin/sips -s format png -z 256 256 -s dpiHeight 144.0 -s dpiWidth 144.0 ${png} --out ${tmp}/icon_256@2x.png
+  /usr/bin/sips -s format png -z 128 128 -s dpiHeight 72.0 -s dpiWidth 72.0 ${png} --out ${tmp}/icon_256.png
+  /usr/bin/tiffutil -cathidpicheck ${tmp}/icon_64x64@2x.png ${tmp}/icon_64x64.png ${tmp}/icon_96.png ${tmp}/icon_96@2x.png ${tmp}/icon_256.png ${tmp}/icon_256@2x.png -out ${target}/ disk.tiff
+  ```
 3. Use the command ``` base64 ./disk.tiff -b 70 ``` to generate the base64 version of the multi-TIFF file. This final version will be used for the connection profile.
 
 ## Sample Connection Profiles

--- a/protocols/s3/alibaba.md
+++ b/protocols/s3/alibaba.md
@@ -1,18 +1,18 @@
 Alibaba Cloud Object Storage Service (OSS)
 ====
 
-```{image} https://cdn.cyberduck.io/img/providers/alibaba.png
+:::{image} https://cdn.cyberduck.io/img/providers/alibaba.png
 :alt: Alibaba Cloud Object Storage Service
 :width: 128px
-```
+:::
 
 > [Alibaba Cloud Object Storage Service (OSS)](https://www.alibabacloud.com/help/doc-detail/31817.htm) is a storage service that enables you to store, back up, and archive any amount of data in the cloud. OSS is a cost-effective, highly secure, and highly reliable cloud storage solution. It uses RESTful APIs and provides 99.9999999999% (12 nines) durability (designed for) and 99.995% availability or service continuity (designed for).
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### Connection Profile
 

--- a/protocols/s3/digitalocean.md
+++ b/protocols/s3/digitalocean.md
@@ -1,18 +1,18 @@
 DigitalOcean Spaces
 ====
 
-```{image} https://cdn.cyberduck.io/img/providers/digitaloceanspaces.png
+:::{image} https://cdn.cyberduck.io/img/providers/digitaloceanspaces.png
 :alt: DigitalOcean Spaces Drive Icon
 :width: 128px
-```
+:::
 
 > [Spaces](https://www.digitalocean.com/products/object-storage/), a beautifully simple and scalable object storage service. Securely store and deliver any amount of data with the same simplicity you've come to expect from us. Instantaneously create a cost-effective, reliable storage space using our drag-and-drop UI or API.
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### AMS3
 

--- a/protocols/s3/dreamobjects.md
+++ b/protocols/s3/dreamobjects.md
@@ -1,20 +1,20 @@
 DreamObject Cloud Storage
 ====
 
-```{image} https://cdn.cyberduck.io/img/providers/dreamobjects.png
+:::{image} https://cdn.cyberduck.io/img/providers/dreamobjects.png
 :alt: DreamObject Cloud Storage
 :width: 128px
-```
+:::
 
 > [DreamObjects](http://dreamhost.com/cloud/dreamobjects/) is a cost-effective, public cloud storage service built on top of the open source technology [Ceph](http://ceph.io/). It is compatible with the APIs of [Amazon S3](index.md) and [Swift](../openstack/index.md) based object storage services.
 
 ## Connecting
 
-```{attention}
+:::{attention}
 `us-west-1` was shut down
 
 See the article [What DreamObjects hostname should I use to connect?](https://help.dreamhost.com/hc/en-us/articles/360001370846) for more information.
-```
+:::
 
 - `us-east-1` {download}`Download<https://profiles.cyberduck.io/DreamObjects%20(us-east-1).cyberduckprofile>` the *DreamObjects Cloud Storage Connection Profile* or install it from *Preferences… → Profiles* for preconfigured settings. 
 - Alternatively, use `objects-us-east-1.dream.io` for the hostname in Open Connection or Bookmark settings with a *S3* protocol selection. Then user your *Access Key* for the username and *Secret Key* for the password.

--- a/protocols/s3/dunkel.md
+++ b/protocols/s3/dunkel.md
@@ -1,10 +1,10 @@
 Dunkel Cloud Storage
 ====
 
-```{image} _images/Dunkel_Cloud_Storage.png
+:::{image} _images/Dunkel_Cloud_Storage.png
 :alt: Dunkel Cloud Storage Drive Icon
 :width: 128px
-```
+:::
 
 > [Dunkel Cloud Storage](http://www.dunkel.de/s3/) ist ein S3 kompatibler Cloud Storage in deutschen Rechenzentren. 
 

--- a/protocols/s3/garage.md
+++ b/protocols/s3/garage.md
@@ -1,10 +1,10 @@
 Garage
 ====
 
-```{image} _images/garage.png
+:::{image} _images/garage.png
 :alt: Garage Logo
 :width: 128px
-```
+:::
 
 > [Garage](https://garagehq.deuxfleurs.fr/) is an open-source distributed object storage service tailored for self-hosting.
 

--- a/protocols/s3/iam.md
+++ b/protocols/s3/iam.md
@@ -11,44 +11,50 @@ You can manage IAM users using the [AWS Console](https://console.aws.amazon.com/
 
 - Download the [IAM Command Line Toolkit](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/index.html). Unzip the download and move the folder `IAMCli-1.2.0` into the `bin` folder in your user home directory.
 - In a Terminal.app window, set the home environment for IAM
-
-		echo 'export JAVA_HOME=`/usr/libexec/java_home`' >> ~/.bash_profile
-		echo 'export AWS_IAM_HOME=~/bin/IAMCli-1.2.0' >> ~/.bash_profile
-
+```
+echo 'export JAVA_HOME=`/usr/libexec/java_home`' >> ~/.bash_profile
+echo 'export AWS_IAM_HOME=~/bin/IAMCli-1.2.0' >> ~/.bash_profile
+```
 - Set the environment variable to point to the credentials file.
-
-		echo 'export AWS_CREDENTIAL_FILE=$AWS_IAM_HOME/aws-credential.template' >> ~/.bash_profile
-
+```
+echo 'export AWS_CREDENTIAL_FILE=$AWS_IAM_HOME/aws-credential.template' >> ~/.bash_profile
+```
 - Add the path to the IAM programs to your path
-
-		echo 'export PATH=$AWS_IAM_HOME/bin:$PATH' >> ~/.bash_profile
-
+```
+echo 'export PATH=$AWS_IAM_HOME/bin:$PATH' >> ~/.bash_profile
+```
 - Update the environment of the current shell (alternatively open a new Terminal.app window).
-
-		. ~/.bash_profile
-
+```
+. ~/.bash_profile
+```
 - Edit the credentials file `aws-credential.template` with your AWS identifiers.
 
 ## Create a new IAM User
 
 Add a new IAM user and generate the access credentials. This will print out the *Access Key ID* and *Secret Access Key* to use when logging in with Cyberduck.
 
-	iam-usercreate -u <username>;iam-useraddkey -u <username>
+```
+iam-usercreate -u <username>;iam-useraddkey -u <username>
+```
 
 ## Attach a Policy
 
 Add a new policy for the user. This example gives the user access to all of your S3 resources.
 
-	iam-useraddpolicy  -u <username> -e Allow -a s3:* -r arn:aws:s3:::* -o -p `uuidgen`
+```
+iam-useraddpolicy  -u <username> -e Allow -a s3:* -r arn:aws:s3:::* -o -p `uuidgen`
+```
 
 ### Restrict Access to a Specific Bucket
 
 - Allow user to list contents of the bucket.
-
-		iam-useraddpolicy  -u <username> -e Allow -a s3:ListBucket -r arn:aws:s3:::bucketname -o -p `uuidgen`
+```
+iam-useraddpolicy  -u <username> -e Allow -a s3:ListBucket -r arn:aws:s3:::bucketname -o -p `uuidgen`
+```
 - Allow users to download files in the bucket.
-
-		iam-useraddpolicy  -u <username> -e Allow -a s3:GetObject -r arn:aws:s3:::bucketname/* -o -p `uuidgen`
+```
+iam-useraddpolicy  -u <username> -e Allow -a s3:GetObject -r arn:aws:s3:::bucketname/* -o -p `uuidgen`
+```
 
 ## Connecting
 

--- a/protocols/s3/ibmcos.md
+++ b/protocols/s3/ibmcos.md
@@ -1,10 +1,10 @@
 IBM Cloud Object Storage (COS)
 ====
 
-```{attention}
+:::{attention}
 - [**Softlayer is now IBM Cloud.**](https://www.ibm.com/cloud/info/softlayer-is-now-ibm-cloud)
 - [**IBM Bluemix has been rebranded as IBM Cloud within October 2017.**](https://www.ibm.com/cloud/blog/announcements/bluemix-is-now-ibm-cloudMore)
-```
+:::
 
 > A highly scalable cloud [storage service](https://www.ibm.com/cloud/object-storage), designed for high durability, resiliency, and security.
 

--- a/protocols/s3/index.md
+++ b/protocols/s3/index.md
@@ -1,7 +1,7 @@
 Amazon S3
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 alibaba
@@ -33,204 +33,169 @@ synology
 vitanium
 wasabi
 z1
-```
+:::
 
-```{image} _images/s3.png
+:::{image} _images/s3.png
 :alt: S3 Drive Icon
 :width: 128px
-```
+:::
 
 Transfer files to your [S3](http://aws.amazon.com/s3) account and browse the S3 buckets and files in a hierarchical way.
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Connecting
 
-You must obtain the login credentials (Access Key ID and Secret Access Key) of
-your [Amazon Web Services Account](http://aws.amazon.com/account/) from the [*AWS Access Identifiers
-page*](https://console.aws.amazon.com/iam/home?#security_credential). Enter the *Access Key ID* and *Secret Access Key*
-in the login prompt.
+You must obtain the login credentials (Access Key ID and Secret Access Key) of your [Amazon Web Services Account](http://aws.amazon.com/account/) from the [*AWS Access Identifiers page*](https://console.aws.amazon.com/iam/home?#security_credential). Enter the *Access Key ID* and *Secret Access Key* in the login prompt.
 
 ### IAM User
 
-You can also connect using [IAM](iam.md) credentials that have the `Amazon S3 Full Access` template policy permissions
-attached and optionally the `CloudFront Full Access`.
+You can also connect using [IAM](iam.md) credentials that have the `Amazon S3 Full Access` template policy permissions attached and optionally the `CloudFront Full Access`.
 
 ### Generic S3 Profiles
 
-```{note}
+:::{note}
 Connection profiles for use with third-party S3 installations. can be installed from *Preferences → Profiles*.
-```
+:::
 
-`````{tabs}
-
-````{tab} AWS4
+:::::{tabs}
+::::{tab} AWS4
 
 **Authentication with signature version AWS4-HMAC-SHA256**
 
-```{Important}
+:::{important}
 It is discouraged to enable this option to connect plaintext to Amazon S3.
-```
+:::
 
 If you have an S3 installation without SSL configured, you need an optional connection profile to connect using HTTP only without transport layer security. You will then have the added option S3 (HTTP) in the protocol dropdown selection in the [Connection](../../cyberduck/connection) and [Bookmark](../../cyberduck/bookmarks) panels.
 
 - {download}`Download<https://profiles.cyberduck.io/S3%20(HTTP).cyberduckprofile>` the *S3 (HTTP) profile* for preconfigured settings.
 - *S3 (HTTPS) profile* bundled by default.
-````
 
-````{tab} AWS2
+::::
+::::{tab} AWS2
 
 **Authentication with signature version AWS2**
 
-```{attention}
+:::{attention}
 Connection profiles using legacy AWS2 signature authentication are not recommended to be used with AWS S3 as some regions and features like _Key Management Service_ and _CloudFront configuration_ are not supported.
-```
+:::
 
 - {download}`Download<https://profiles.cyberduck.io/S3%20AWS2%20Signature%20Version%20(HTTP).cyberduckprofile>` the S3 AWS2 Signature Version (HTTP) profile for preconfigured settings.
 - {download}`Download<https://profiles.cyberduck.io/S3%20AWS2%20Signature%20Version%20(HTTPS).cyberduckprofile>` the S3 AWS2 Signature Version (HTTPS) profile for preconfigured settings.
 
-````
-
-````{tab} AWS Gov Cloud
+::::
+::::{tab} AWS Gov Cloud
 
 **S3 GovCloud (US-East)**
 
 Use the endpoint `s3.us-gov-east-1.amazonaws.com` or install the connection profile
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20GovCloud%20(US-East).cyberduckprofile>` the *S3 GovCloud (
-  US-East) profile* for preconfigured settings.
+- {download}`Download<https://profiles.cyberduck.io/S3%20GovCloud%20(US-East).cyberduckprofile>` the *S3 GovCloud (US-East) profile* for preconfigured settings.
 
 **S3 GovCloud (Us-West)**
 
 Use the endpoint `s3.us-gov-west-1.amazonaws.com` or install the connection profile
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20GovCloud%20(US-East).cyberduckprofile>` the *S3 GovCloud (
-  US-West) profile* for preconfigured settings.
+- {download}`Download<https://profiles.cyberduck.io/S3%20GovCloud%20(US-East).cyberduckprofile>` the *S3 GovCloud (US-West) profile* for preconfigured settings.
 
-````
+::::
+::::{tab} AWS China (Beijing)
 
-````{tab} AWS China (Beijing)
 **Connect to the region _AWS China (Beijing)_**
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20China%20(Beijing).cyberduckprofile>` the *S3 China (Beijing)
-  profile* for preconfigured settings.
-- {download}`Download<https://profiles.cyberduck.io/S3%20China%20(Ningxia).cyberduckprofile>` the *S3 China (Ningxia)
-  profile* for preconfigured settings.
+- {download}`Download<https://profiles.cyberduck.io/S3%20China%20(Beijing).cyberduckprofile>` the *S3 China (Beijing) profile* for preconfigured settings.
+- {download}`Download<https://profiles.cyberduck.io/S3%20China%20(Ningxia).cyberduckprofile>` the *S3 China (Ningxia) profile* for preconfigured settings.
 
-````
-
-````{tab} AWS Private Link
+::::
+::::{tab} AWS Private Link
 
 **Connect to [S3 interface VPC endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html)**
 
 - {download}`Download<https://profiles.cyberduck.io/AWS%20PrivateLink%20for%20Amazon%20S3%20(VPC%20endpoint).cyberduckprofile>`
 the *AWS PrivateLink for Amazon S3 (VPC endpoint) profile*.
-````
 
-`````
+::::
+:::::
 
 ### Connecting to a Single Bucket
 
 Connecting to a bucket owned by you or even a third party is possible without requiring permission to list all buckets.
 You can access buckets owned by someone else if the ACL allows you to access it by *either*:
 
-- Specify the bucket you want to access in the hostname to connect to like `<bucketname>.s3.amazonaws.com`. Your own
-  buckets will not be displayed but only this bucket contents
-- Set the *Default Path* in the bookmark to the bucket name. If you have permission you can still navigate one level up
-  to display all buckets if the ACL allows.
+- Specify the bucket you want to access in the hostname to connect to like `<bucketname>.s3.amazonaws.com`. Your own buckets will not be displayed but only this bucket contents
+- Set the *Default Path* in the bookmark to the bucket name. If you have permission you can still navigate one level up to display all buckets if the ACL allows.
 
-```{attention}
+:::{attention}
 No regional endpoint should be set while connecting to a single bucket. The endpoint will be determined automatically by querying the region of the bucket.
-```
+:::
 
 ### Connecting using Deprecated Path Style Requests
 
-For S3 compatible storage only supporting path style requests to reference buckets. Connect with a connection profile
-disabling virtual host style requests.
+For S3 compatible storage only supporting path style requests to reference buckets. Connect with a connection profile disabling virtual host style requests.
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20(Deprecated%20path%20style%20requests).cyberduckprofile>` the
-  *S3 (Deprecated path style requests) profile* for preconfigured settings.
+- {download}`Download<https://profiles.cyberduck.io/S3%20(Deprecated%20path%20style%20requests).cyberduckprofile>` the *S3 (Deprecated path style requests) profile* for preconfigured settings.
 
-Alternatively set the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) `s3.bucket.virtualhost.disable`
-to `true`.
+Alternatively set the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) `s3.bucket.virtualhost.disable` to `true`.
 
-```{admonition} Interoperability
+:::{admonition} Interoperability
 :class: note
 
-Attempting to connect using the regular S3 connection profile to a server with no support for virtual host style requests will cause
-the error `Cannot read container configuration` with the message _DNS is the network service that translates a server name to its Internet address. This error is most often caused by having no connection to the  Internet or a misconfigured network. It can also be caused by an unresponsive DNS server or a firewall preventing access to the network._
-```
+Attempting to connect using the regular S3 connection profile to a server with no support for virtual host style requests will cause the error `Cannot read container configuration` with the message _DNS is the network service that translates a server name to its Internet address. This error is most often caused by having no connection to the  Internet or a misconfigured network. It can also be caused by an unresponsive DNS server or a firewall preventing access to the network._
+:::
 
 ### Connecting with OpenID Connect (OIDC) Identity Provider
 
-```{important}
-* Cyberduck [8.7.0](https://cyberduck.io/changelog/) or later required
-* Mountain Duck [4.15.0](https://mountainduck.io/changelog/) or later required
-```
+:::{important}
+- Cyberduck [8.7.0](https://cyberduck.io/changelog/) or later required
+- Mountain Duck [4.15.0](https://mountainduck.io/changelog/) or later required
+:::
 
-Connecting to AWS S3 with web identity federation using AWS Security Token Service (STS) is supported with connection
-profiles specifying configuration properties specific to your identity provider (IdP).
+Connecting to AWS S3 with web identity federation using AWS Security Token Service (STS) is supported with connection profiles specifying configuration properties specific to your identity provider (IdP).
 
-```{attention}
+:::{attention}
 The usage of these connection profiles requires the [configuration](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) of an OpenID Connect (OIDC) identity provider and role and trust policy in AWS IAM.
-```
+:::
 
-The connection profiles connect using temporary security credentials from the AWS Security Token Service (STS) obtained
-using a web identity token from your OpenID Connect (OIDC) identity provider. Refer
-to [Custom connection profile using OpenID Connect provider and AssumeRoleWithWebIdentity STS API](../profiles/aws_oidc.md).
+The connection profiles connect using temporary security credentials from the AWS Security Token Service (STS) obtained using a web identity token from your OpenID Connect (OIDC) identity provider. Refer to [Custom connection profile using OpenID Connect provider and AssumeRoleWithWebIdentity STS API](../profiles/aws_oidc.md).
 
-```{admonition} Interoperability
+:::{admonition} Interoperability
 `AssumeRoleWithWebIdentity` API from AWS Security Token Service (STS) is used to exchange the JSON Web Token with temporary security credentials. In addition to AWS, the following combinations of S3 & STS APIs with OpenID Connect (OIDC) have been tested:
 - Connect to MinIO S3 authenticating with [MinIO STS](https://min.io/docs/minio/linux/developers/security-token-service.html) and Keycloak (OIDC)
 - Connect to AWS S3 authenticating with AWS STS and Keycloak (OIDC)
-```
+:::
 
 #### Sample Connection Profiles for Authorization with Well Known Identity Providers
 
-```{note}
+:::{note}
 When connecting the user is requested to enter the Role ARN of the IAM role that has a trust relationship configured with the identity provider in _Identity and Access Management (IAM)_.
-```
+:::
 
 ##### S3 with Azure Active Directory (Azure AD)
 
-- {download}`Download<https://profiles.cyberduck.io/AWS%20S3%2BSTS%20%26%20Azure%20Active%20Directory%20%28Azure%20AD%29%20OpenID%20Connect.cyberduckprofile>`
-the *AWS S3+STS &amp; Azure Active Directory (Azure AD) profile* for preconfigured settings
+- {download}`Download<https://profiles.cyberduck.io/AWS%20S3%2BSTS%20%26%20Azure%20Active%20Directory%20%28Azure%20AD%29%20OpenID%20Connect.cyberduckprofile>` the *AWS S3+STS &amp; Azure Active Directory (Azure AD) profile* for preconfigured settings
 
 ##### S3 with Google OpenID Connect
 
-- {download}`Download<https://profiles.cyberduck.io/AWS%20S3%2BSTS%20%26%20Google%20OpenID%20Connect.cyberduckprofile>`
-  the *AWS S3+STS &amp; Google OpenID Connect profile* for preconfigured settings
+- {download}`Download<https://profiles.cyberduck.io/AWS%20S3%2BSTS%20%26%20Google%20OpenID%20Connect.cyberduckprofile>` the *AWS S3+STS &amp; Google OpenID Connect profile* for preconfigured settings
 
 ### Connecting with Temporary Access Credentials (Token) from EC2
 
-If you are running Cyberduck for Windows or [Cyberduck CLI](https://duck.sh/) on EC2 and have
-setup [IAM Roles for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) to
-provide access to S3 from the EC2 instance, you can use the connection profile below that will fetch temporary
-credentials from EC2 instance metadata service
-at `http://169.254.169.254/latest/meta-data/iam/security-credentials/s3access` to authenticate. Edit the profile to
-change the role name `s3access` to match your IAM configuration.
+If you are running Cyberduck for Windows or [Cyberduck CLI](https://duck.sh/) on EC2 and have setup [IAM Roles for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) to provide access to S3 from the EC2 instance, you can use the connection profile below that will fetch temporary credentials from EC2 instance metadata service at `http://169.254.169.254/latest/meta-data/iam/security-credentials/s3access` to authenticate. Edit the profile to change the role name `s3access` to match your IAM configuration.
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20(Credentials%20from%20Instance%20Metadata).cyberduckprofile>`
-  the *S3 (Credentials from Instance Metadata) profile* for preconfigured settings
+- {download}`Download<https://profiles.cyberduck.io/S3%20(Credentials%20from%20Instance%20Metadata).cyberduckprofile>` the *S3 (Credentials from Instance Metadata) profile* for preconfigured settings
 
 ### Connecting Using Credentials from AWS Command Line Interface
 
-Instead of providing Access Key ID and Secret Access Key, authenticate using credentials managed in `~/aws/credentials`
-on macOS or `%USERPROFILE%\.aws\credentials` on Windows using third-party tools.
+Instead of providing Access Key ID and Secret Access Key, authenticate using credentials managed in `~/aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows using third-party tools.
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20(Credentials%20from%20AWS%20Command%20Line%20Interface).cyberduckprofile>`
-the *S3 (Credentials from AWS Command Line Interface) profile* for preconfigured settings.
+- {download}`Download<https://profiles.cyberduck.io/S3%20(Credentials%20from%20AWS%20Command%20Line%20Interface).cyberduckprofile>` the *S3 (Credentials from AWS Command Line Interface) profile* for preconfigured settings.
 
-You must provide configuration in the standard credentials property file `~/.aws/credentials` on macOS
-or `%USERPROFILE%\.aws\credentials` on Windows as well as the config file `~/aws/config` on macOS
-or `%USERPROFILE%\.aws\config` on Windows
-from [AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
-Configure a bookmark with the field titled *Profile Name in` ~/.aws/credentials`* matching the profile name
-from `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows. The
-properties `aws_access_key_id`, `aws_secret_access_key` and `aws_session_token` are supported.
+You must provide configuration in the standard credentials property file `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows as well as the config file `~/aws/config` on macOS or `%USERPROFILE%\.aws\config` on Windows from [AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
+Configure a bookmark with the field titled *Profile Name in` ~/.aws/credentials`* matching the profile name from `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows. The properties `aws_access_key_id`, `aws_secret_access_key` and `aws_session_token` are supported.
 
 You might be interested in scripts maintained by third parties to facilitate managing credentials
 
@@ -238,93 +203,86 @@ You might be interested in scripts maintained by third parties to facilitate man
 
 #### AWS IAM Identity Center
 
-For a SSO connection authenticating with AWS IAM Identity Center (Successor to AWS Single Sign-On), the
-properties `sso_start_url`, `sso_account_id`, and `sso_role_name` are required within the standard credentials property
-file `~/.aws/credentials` (macOS) or `%USERPROFILE%\.aws\credentials` (Windows). The access key, secret key, and session
-token cached by AWS CLI are retrieved from `~/.aws/cli/cache` on macOS or `%USERPROFILE%\.aws\cli\cache` on Windows.
+For a SSO connection authenticating with AWS IAM Identity Center (Successor to AWS Single Sign-On), the properties `sso_start_url`, `sso_account_id`, and `sso_role_name` are required within the standard credentials property file `~/.aws/credentials` (macOS) or `%USERPROFILE%\.aws\credentials` (Windows). The access key, secret key, and session token cached by AWS CLI are retrieved from `~/.aws/cli/cache` on macOS or `%USERPROFILE%\.aws\cli\cache` on Windows.
 
 To populate the correct cache locations follow these steps:
 
-1. Run the command `aws sso login` to populate `~/.aws/sso/cache` on macOS or
-   respectively `%USERPROFILE%\.aws\sso\cache` on Windows. This adds client secrets but doesn't add any usable AWS
-   credentials.
-2. Seed the second cache in `~/.aws/cli/cache` on macOS or respectively `%USERPROFILE%\.aws\cli\cache` on Windows by
-   running the command `aws sts get-caller-identity`. This adds the usable credentials to the location Cyberduck and
-   Mountain Duck reads from.
+1. Run the command `aws sso login` to populate `~/.aws/sso/cache` on macOS or respectively `%USERPROFILE%\.aws\sso\cache` on Windows. This adds client secrets but doesn't add any usable AWS credentials.
+2. Seed the second cache in `~/.aws/cli/cache` on macOS or respectively `%USERPROFILE%\.aws\cli\cache` on Windows by running the command `aws sts get-caller-identity`. This adds the usable credentials to the location Cyberduck and Mountain Duck reads from.
 
-```{note}
+:::{note}
 You can also do this for a specific profile by adding `--profile myProfile` to the commands. Make sure to use the same profile for both steps.
-```
+:::
 
 - [Configuring the AWS CLI to use AWS Single Sign-On](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)
 
 #### Connecting Using AssumeRole from AWS Security Token Service (STS)
 
-Instead of providing Access Key ID and Secret Access Key, authenticate using temporary credentials from AWS Security
-Token Service (STS) with optional Multi-Factor Authentication (MFA). Refer
-to [Using IAM Roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html).
+Instead of providing Access Key ID and Secret Access Key, authenticate using temporary credentials from AWS Security Token Service (STS) with optional Multi-Factor Authentication (MFA). Refer to [Using IAM Roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html).
 
 ![MFA Token Prompt](_images/MFA_Token_Prompt.png)
 
-You must provide configuration in the standard credentials property file `~/.aws/credentials` on macOS
-or `%USERPROFILE%\.aws\credentials` on Windows
-from [AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
-Configure a bookmark with the field titled *Profile Name in `~/.aws/credentials`* matching the profile name
-from `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows with the `role_arn` configuration.
+You must provide configuration in the standard credentials property file `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows from [AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html).
+Configure a bookmark with the field titled *Profile Name in `~/.aws/credentials`* matching the profile name from `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows with the `role_arn` configuration.
 
 #### Example Configuration
 
 Refer to [Assuming a Role](https://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html).
 
-	[testuser]
-	aws_access_key_id=<access key for testuser>
-	aws_secret_access_key=<secret key for testuser>
-	[testrole]
-	role_arn=arn:aws:iam::123456789012:role/testrole
-	source_profile=testuser
-	mfa_serial=arn:aws:iam::123456789012:mfa/testuser
+```
+[testuser]
+aws_access_key_id=<access key for testuser>
+aws_secret_access_key=<secret key for testuser>
+[testrole]
+role_arn=arn:aws:iam::123456789012:role/testrole
+source_profile=testuser
+mfa_serial=arn:aws:iam::123456789012:mfa/testuser
+```
 
 ### Read Credentials from `~/.aws/credentials`
 
-When editing a bookmark, the *Access Key ID* is set from the `default` profile in the credentials file located
-at `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows if such a profile exists.
+When editing a bookmark, the *Access Key ID* is set from the `default` profile in the credentials file located at `~/.aws/credentials` on macOS or `%USERPROFILE%\.aws\credentials` on Windows if such a profile exists.
 
 ### Connecting Without Using AWS credentials
 
-Use the *S3 (HTTPS)* connection profile to access public data sets on [AWS Open Data](https://registry.opendata.aws/)
-without using access keys by using the *Anonymous Login* option in the bookmark configuration.
+Use the *S3 (HTTPS)* connection profile to access public data sets on [AWS Open Data](https://registry.opendata.aws/) without using access keys by using the *Anonymous Login* option in the bookmark configuration.
 
-```{image} _images/S3_Anonymous_Login.png
+:::{image} _images/S3_Anonymous_Login.png
 :alt: S3 Anonymous Login
 :width: 400px
-```
+:::
 
-- {download}`Download<https://profiles.cyberduck.io/S3%20(HTTPS).cyberduckprofile>` the *S3 (HTTPS) profile* for
-  preconfigured settings
+- {download}`Download<https://profiles.cyberduck.io/S3%20(HTTPS).cyberduckprofile>` the *S3 (HTTPS) profile* for preconfigured settings
 
 ## Cyberduck CLI
 
 List all buckets with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --username <Access Key ID> --list s3:/
+```
+duck --username <Access Key ID> --list s3:/
+```
 
 List the contents of a bucket with
 
-	duck --username <Access Key ID>  --list s3:/<bucketname>/
+```
+duck --username <Access Key ID>  --list s3:/<bucketname>/
+```
 
 Refer to the [Cyberduck CLI documentation](../../cli/index.md) for more operations.
 
 ### Uploads Using CLI
 
-Add default metadata for uploads using
-the [preferences option to read from the environment](../../cli/index.md#preferences). The property is documented
-in [Default metadata](#default-metadata).
+Add default metadata for uploads using the [preferences option to read from the environment](../../cli/index.md#preferences). The property is documented in [Default metadata](#default-metadata).
 
-	env "s3.metadata.default=Content-Type=application/xml" duck --upload …
+```
+env "s3.metadata.default=Content-Type=application/xml" duck --upload …
+```
 
 Set a default ACL for the upload with
 
-	env "s3.acl.default=public-read" duck --upload …
+```
+env "s3.acl.default=public-read" duck --upload …
+```
 
 ## Third-Party Providers
 
@@ -374,16 +332,13 @@ Here is a non-exhaustive list:
 
 ### Creating a Bucket
 
-To create a new [bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket-s3.html) for your
-account, browse to the root and choose *File → New Folder... (macOS `⌘N` Windows `Ctrl+Shift+N`)*. You can choose the
-bucket location in *Preferences (macOS `⌘,` Windows `Ctrl+,`) → S3*. Note that Amazon has a different pricing scheme for
-different regions.
+To create a new [bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket-s3.html) for your account, browse to the root and choose *File → New Folder... (macOS `⌘N` Windows `Ctrl+Shift+N`)*. You can choose the bucket location in *Preferences (macOS `⌘,` Windows `Ctrl+,`) → S3*. Note that Amazon has a different pricing scheme for different regions.
 
-```{admonition} Mountain Duck
+:::{admonition} Mountain Duck
 :class: note
 
 You will receive a prompt for the region when creating a new bucket
-```
+:::
 
 **Supported Regions**
 
@@ -408,39 +363,34 @@ You will receive a prompt for the region when creating a new bucket
 
 ![Create Bucket](_images/Create_Bucket.png)
 
-```{important}
+:::{important}
 - Because the bucket name must be globally unique the operation might fail if the name is already taken by someone else (E.g. don't assume any common name like *media* or *images* will be available).
 - You cannot change the location of an existing bucket.
-```
+:::
 
 ### Bucket Access Logging
 
-When this option is enabled in the S3 panel of the Info (*File → Info (macOS `⌘I` Windows `Alt+Return`)*) window for a
-bucket or any file within, available log records for this bucket are periodically aggregated into log files and
-delivered to `/logs` in the target logging bucket specified. It is considered best practice to choose a logging target
-that is different from the origin bucket.
+When this option is enabled in the S3 panel of the Info (*File → Info (macOS `⌘I` Windows `Alt+Return`)*) window for a bucket or any file within, available log records for this bucket are periodically aggregated into log files and delivered to `/logs` in the target logging bucket specified. It is considered best practice to choose a logging target that is different from the origin bucket.
 
 ![AWS Logging Configuration](_images/AWS_Logging_Configuration.png)
 
-To toggle CloudFront access logging, select the the [Distribution](../../protocols/cdn/cloudfront.md) panel in the
-File → Info (macOS `⌘I` Windows `Alt+Return`) window.
+To toggle CloudFront access logging, select the the [Distribution](../../protocols/cdn/cloudfront.md) panel in the File → Info (macOS `⌘I` Windows `Alt+Return`) window.
 
 ### Requester Pays Buckets
 
-Per default, buckets are accessed with the parameter `x-amz-requester-payer` in the header to allow access to files in
-buckets with the *Requester Pays* option enabled.
+Per default, buckets are accessed with the parameter `x-amz-requester-payer` in the header to allow access to files in buckets with the *Requester Pays* option enabled.
 
-You can change the parameter using the
-following [hidden configuration options](../../cyberduck/preferences.md#hidden-configuration-options).
+You can change the parameter using the following [hidden configuration options](../../cyberduck/preferences.md#hidden-configuration-options).
 
+```
 	s3.bucket.requesterpays=true
+```
 
-* [Using Requester Pays buckets for storage transfers and usage](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html)
+- [Using Requester Pays buckets for storage transfers and usage](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html)
 
 ### Versions
 
-[Versioning](http://aws.amazon.com/s3/faqs/#What_is_Versioning) can be enabled per bucket in *File → Info (macOS `⌘I`
-Windows `Alt+Return`) → S3*. Make sure the user has the following permissions:
+[Versioning](http://aws.amazon.com/s3/faqs/#What_is_Versioning) can be enabled per bucket in *File → Info (macOS `⌘I` Windows `Alt+Return`) → S3*. Make sure the user has the following permissions:
 
 - `s3:PutBucketVersioning` to permit users to modify the versioning configuration of a bucket.
 - `s3:GetBucketVersioning` and `s3:ListBucketVersions` to see versions of a file.
@@ -459,11 +409,7 @@ To revert to a previous version and make it the current, choose *File → Revert
 
 #### Multi-Factor Authentication (MFA) Delete
 
-To enable *Multi-Factor Authentication (MFA) Delete*, you need to purchase a
-compatible [authentication device](http://aws.amazon.com/mfa/). Toggle MFA in *File → Info (macOS `⌘I`
-Windows `Alt+Return`) → S3*. When enabled, you are prompted for the device number and one-time token in the login
-prompt. Never reenter a token in the prompt already used before. A token is only valid for a single request. Wait for
-the previous token to disappear from the device screen and request a new token from the device.
+To enable *Multi-Factor Authentication (MFA) Delete*, you need to purchase a compatible [authentication device](http://aws.amazon.com/mfa/). Toggle MFA in *File → Info (macOS `⌘I` Windows `Alt+Return`) → S3*. When enabled, you are prompted for the device number and one-time token in the login prompt. Never reenter a token in the prompt already used before. A token is only valid for a single request. Wait for the previous token to disappear from the device screen and request a new token from the device.
 
 ![MFA Credentials](_images/MFA_Credentials.png)
 
@@ -473,51 +419,44 @@ the previous token to disappear from the device screen and request a new token f
 
 ### Folders
 
-Creating a folder inside a bucket will create a placeholder object named after the directory, has no data content, and
-the MIME type `application/x-directory`. This is interoperable with folders created
-with [AWS Management Console](http://aws.amazon.com/console/).
+Creating a folder inside a bucket will create a placeholder object named after the directory, has no data content, and the MIME type `application/x-directory`. This is interoperable with folders created with [AWS Management Console](http://aws.amazon.com/console/).
 
-* [Organizing objects in the Amazon S3 console using folders](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html)
+- [Organizing objects in the Amazon S3 console using folders](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html)
 
-```{important}
+:::{important}
 Do not name objects in S3 containing `/` as this will break navigation.
-```
+:::
 
 ## File Transfers
 
 ### Transfer Acceleration
 
-When [enabled](../../cyberduck/info.md#provider-panel) for the bucket, downloads and uploads use the _S3 Transfer Acceleration_ 
-endpoints to transfer data through the globally distributed edge locations of AWS CloudFront. 
+When [enabled](../../cyberduck/info.md#provider-panel) for the bucket, downloads and uploads use the _S3 Transfer Acceleration_ endpoints to transfer data through the globally distributed edge locations of AWS CloudFront. 
 
-```{warning}
+:::{warning}
 The name of the bucket used for Transfer Acceleration must be DNS-compliant and must not contain periods ("."). 
-```
+:::
 
-```{important}
+:::{important}
 You do **not** need to enter transfer accelerated endpoints manually. When using Transfer Acceleration, additional data transfer charges may apply to connect to `s3-accelerate.dualstack.amazonaws.com`.
-```
+:::
 
-```{note}
-Make sure the IAM user has the `s3:GetAccelerateConfiguration` permission required to query the Transfer Acceleration
-status of a bucket.
-```
+:::{note}
+Make sure the IAM user has the `s3:GetAccelerateConfiguration` permission required to query the Transfer Acceleration status of a bucket.
+:::
 
 ### Checksums
 
 Files are verified both by AWS when the file is received and compared with the `SHA256` checksum sent with the request.
-Additionally, the checksum returned by AWS for the uploaded file is compared with the checksum computed locally if
-enabled in *Transfers → Checksum → Uploads → Verify checksum*.
+Additionally, the checksum returned by AWS for the uploaded file is compared with the checksum computed locally if enabled in *Transfers → Checksum → Uploads → Verify checksum*.
 
 ### Multipart Uploads
 
-Files larger than 100MB are uploaded in parts with up to 10 parallel connections as 10MB parts. Given these sizes, the
-file size limit is 100GB with a maximum of 10'000 parts allowed by S3. The number of connections used can be limited
-using the toggle in the lower right of the transfer window.
+Files larger than 100MB are uploaded in parts with up to 10 parallel connections as 10MB parts. Given these sizes, the file size limit is 100GB with a maximum of 10'000 parts allowed by S3. The number of connections used can be limited using the toggle in the lower right of the transfer window.
 
-```{note}
+:::{note}
 Multipart uploads can be resumed later when interrupted. Make sure the IAM user has the permission `s3:ListBucketMultipartUploads`.
-```
+:::
 
 #### Unfinished Multipart Uploads
 
@@ -525,26 +464,20 @@ You can view unfinished multipart uploads in the browser by choosing *View → S
 
 #### Options
 
-You can set options with the
-following [hidden configuration options](../../cyberduck/preferences.md#hidden-configuration-options).
+You can set options with the following [hidden configuration options](../../cyberduck/preferences.md#hidden-configuration-options).
 
-* Part size for multipart uploads
-
+- Part size for multipart uploads
 ```
 s3.upload.multipart.size=10485760
 ```
-
-* Threshold to use multipart uploads is set to 100MB by default
-
+- Threshold to use multipart uploads is set to 100MB by default
 ```
 s3.upload.multipart.threshold=104857600
 ```
 
 ## Storage Class
 
-You have the option to store files using the *Reduced Redundancy Storage (RRS)* by storing non-critical, reproducible
-data at lower levels of redundancy. Set the default storage class in *Preferences (macOS `⌘,` Windows `Ctrl+,`) → S3*
-and [edit the storage class](../../cyberduck/info.md#provider-panel) for already uploaded files using *File → Info (
+You have the option to store files using the *Reduced Redundancy Storage (RRS)* by storing non-critical, reproducible data at lower levels of redundancy. Set the default storage class in *Preferences (macOS `⌘,` Windows `Ctrl+,`) → S3* and [edit the storage class](../../cyberduck/info.md#provider-panel) for already uploaded files using *File → Info (
 macOS `⌘I` Windows `Alt+Return`) → S3*. Available storage classes are
 
 - Regular Amazon S3 Storage
@@ -563,40 +496,38 @@ Specify after how many days a file in a bucket should be moved to Amazon Glacier
 
 ## Restore from Glacier
 
-```{attention}
+:::{attention}
 This function is currently Cyberduck only.
-```
+:::
 
-You can temporarily restore files from *Glacier* and *Glacier Deep Archive* using *File → Restore*. The file will be
-restored using standard retrieval and expire 2 days after retrieval. Restoring takes some time and attempting to
-download an item not yet restored will lead to an error *The operation is not valid for the object's storage class*.
+You can temporarily restore files from *Glacier* and *Glacier Deep Archive* using *File → Restore*. The file will be restored using standard retrieval and expire 2 days after retrieval. Restoring takes some time and attempting to download an item not yet restored will lead to an error *The operation is not valid for the object's storage class*.
 
 ### Glacier Retrieval Options
 
-You can set retrieval options for the storage classes *Glacier* and *Glacier Deep Archive* with the
-following [hidden configuration options](../../cyberduck/preferences.md#hidden-configuration-options).
+You can set retrieval options for the storage classes *Glacier* and *Glacier Deep Archive* with the following [hidden configuration options](../../cyberduck/preferences.md#hidden-configuration-options).
 
 Sets Glacier retrieval tier at which the restore will be processed.
 
-	s3.glacier.restore.tier=Standard
+```
+s3.glacier.restore.tier=Standard
+```
 
 → Valid values are `Standard`, `Bulk`, `Expedited`.
 
 Sets the time, in days, between when an object is uploaded to the bucket and when it expires.
 
-	s3.glacier.restore.expiration.days=2
+```
+s3.glacier.restore.expiration.days=2
+```
 
 ### Restored Glacier Files in Mountain Duck
 
 Temporarily restored files from *Glacier* won't change the storage class and therefore won't be listed by Mountain Duck.
-To make restored Glacier files available in Mountain Duck make sure to change the file's storage class in the S3 tab of
-the [Cyberduck Info window](../../cyberduck/info.md#provider-panel).
+To make restored Glacier files available in Mountain Duck make sure to change the file's storage class in the S3 tab of the [Cyberduck Info window](../../cyberduck/info.md#provider-panel).
 
 ## Access Control (ACL)
 
-Amazon S3 uses Access Control List (ACL) settings to control who may access or modify items stored in S3. You can edit
-ACLs in *File → Info (macOS `⌘I` Windows `Alt+Return`) → Permissions*. Alternatively, permissions can be changed
-using [bucket policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html).
+Amazon S3 uses Access Control List (ACL) settings to control who may access or modify items stored in S3. You can edit ACLs in *File → Info (macOS `⌘I` Windows `Alt+Return`) → Permissions*. Alternatively, permissions can be changed using [bucket policies](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html).
 
 ![ACLs](_images/ACLs.png)
 
@@ -606,25 +537,18 @@ If you enter a user ID unknown to AWS, the error message `S3 Error Message. Bad 
 
 ### Email Address Grantee
 
-If you enter an email address unknown to AWS, the error message `S3 Error Message. Bad Request. Invalid id.` will be
-displayed. If multiple accounts are registered with AWS for the given email address, the error
-message `Bad Request. The e-mail address you provided is associated with more than one account. Please retry your request using a different identification method or after resolving the ambiguity.`
-is returned.
+If you enter an email address unknown to AWS, the error message `S3 Error Message. Bad Request. Invalid id.` will be displayed. If multiple accounts are registered with AWS for the given email address, the error message `Bad Request. The e-mail address you provided is associated with more than one account. Please retry your request using a different identification method or after resolving the ambiguity.` is returned.
 
 ### All Users Group Grantee
 
-You must give the group grantee `http://acs.amazonaws.com/groups/global/AllUsers` read permissions for your objects to
-make them accessible using a regular web browser for everyone.
+You must give the group grantee `http://acs.amazonaws.com/groups/global/AllUsers` read permissions for your objects to make them accessible using a regular web browser for everyone.
 
-If [bucket logging](index.md#bucket-access-logging) is enabled, the bucket ACL will have `READ_ACP` and `WRITE`
-permissions for the group grantee `http://acs.amazonaws.com/groups/s3/LogDelivery`.
+If [bucket logging](index.md#bucket-access-logging) is enabled, the bucket ACL will have `READ_ACP` and `WRITE` permissions for the group grantee `http://acs.amazonaws.com/groups/s3/LogDelivery`.
 
 ### Default ACLs
 
-You can choose *canned ACLs* to be added to uploaded files or created buckets per default. *Canned ACLs* are predefined
-sets of permissions.
-The [default ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) can be set within
-*Preferences (macOS `⌘,` Windows `Ctrl+,`) → S3 → Default ACL*.
+You can choose *canned ACLs* to be added to uploaded files or created buckets per default. *Canned ACLs* are predefined sets of permissions.
+The [default ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) can be set within *Preferences (macOS `⌘,` Windows `Ctrl+,`) → S3 → Default ACL*.
 
 |                             | Applies to buckets | Applies to files |
 |-----------------------------|:------------------:|:----------------:|
@@ -638,9 +562,9 @@ The [default ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-over
 You can [disable the ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) using the
 _Amazon S3 Object Ownership_.
 
-```{note}
+:::{note}
 You need to set _Preferences → S3 → Default ACL → None_ for uploads with disabled ACLs to succeed. Otherwise uploads fail with `The bucket does not allow ACLs.`.
-```
+:::
 
 ### Permissions
 
@@ -654,108 +578,86 @@ The following permissions can be given to grantees:
 | `READ_ACP`     | Allows grantee to read the bucket ACL                                  | Allows grantee to read the file ACL                     |
 | `WRITE_ACP`    | Allows grantee to write the ACL for the applicable bucket              | Allows grantee to write the ACL for the applicable file |
 
-```{attention}
+:::{attention}
 You may receive an error *Cannot change permissions of* when attempting to grant *Everyone READ* permission for a file if the bucket has public access blocked because [Block Public Access settings](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html) are turned on for this bucket.
-```
+:::
 
 ## Public URLs
 
-You can access all URLs (including from [CDN](../../protocols/cdn/cloudfront.md) configurations) from the menu *Edit →
-Copy URL and File → Open URL*.
+You can access all URLs (including from [CDN](../../protocols/cdn/cloudfront.md) configurations) from the menu *Edit → Copy URL and File → Open URL*.
 
 ![Copy URLs](_images/Copy_URLs.png)
 
-```{important}
+:::{important}
 Public URLs are only accessible if the permission `READ` is granted for `EVERYONE`.
-```
+:::
 
-Choose *File → Share…* to change the ACL on the file permanently allowing read for everyone. You can reset the changed
-ACL in [Info → ACL](../../cyberduck/info.md#access-control-list-acl).
+Choose *File → Share…* to change the ACL on the file permanently allowing read for everyone. You can reset the changed ACL in [Info → ACL](../../cyberduck/info.md#access-control-list-acl).
 
 ### Pre-signed Temporary URLs
 
-A private object stored in S3 can be made publicly available for a limited time using a pre-signed URL. The pre-signed
-URL can be used by anyone to download the object, yet it includes a date and time after which the URL will no longer
-work. Copy the pre-signed URL from *Edit → Copy URL→ Signed URL* or *File → Info (macOS `⌘I` Windows `Alt+Return`) →
-S3*.
+A private object stored in S3 can be made publicly available for a limited time using a pre-signed URL. The pre-signed URL can be used by anyone to download the object, yet it includes a date and time after which the URL will no longer work. Copy the pre-signed URL from *Edit → Copy URL→ Signed URL* or *File → Info (macOS `⌘I` Windows `Alt+Return`) → S3*.
 
-There are pre-signed URLs that expire in one hour, 24 hours (using the preference `s3.url.expire.seconds`), a week, and
-a month. You can change
-the [hidden preference](../../cyberduck/preferences.md#hidden-configuration-options) `s3.url.expire.seconds` from the
-default `86400` (24 hours).
+There are pre-signed URLs that expire in one hour, 24 hours (using the preference `s3.url.expire.seconds`), a week, and a month. You can change the [hidden preference](../../cyberduck/preferences.md#hidden-configuration-options) `s3.url.expire.seconds` from the default `86400` (24 hours).
 
-```{important}
+:::{important}
 It is required that your AWS credentials are saved in keychain. Refer to [Passwords](../../cyberduck/connection.md#passwords).
-```
+:::
 
 #### Force use of AWS2 Signature
 
-Using the AWS4 signature version used in Cyberduck 5 and later, pre-signed URLs cannot have an expiry date later than a
-week. You can revert by setting the default signature version to AWS2 by using the *S3 AWS2 Signature Version (HTTP)
-connection profile*.
+Using the AWS4 signature version used in Cyberduck 5 and later, pre-signed URLs cannot have an expiry date later than a week. You can revert by setting the default signature version to AWS2 by using the *S3 AWS2 Signature Version (HTTP) connection profile*.
 
-```{note}
+:::{note}
 This deprecated signature version is not compatible with new regions such as `eu-central-1`.
-```
+:::
 
 ### Limitations
 
 Share links cannot be created when failing to update the ACLs on a file because
 
-* Bucket has "Object Ownership" set to "Bucket owner
+- Bucket has "Object Ownership" set to "Bucket owner
   enforced" ([ACLs disabled](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html?icmpid=docs_amazons3_console)).
   Error message: `This bucket does not allow ACLs`
-* ["Block public access"](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html?icmpid=docs_amazons3_console)
+- ["Block public access"](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html?icmpid=docs_amazons3_console)
   is enabled on bucket. Error message: `Access denied`
 
 ## Metadata
 
-You can edit standard HTTP headers and add [custom HTTP headers](../../cyberduck/info.md#metadata-http-headers) to files
-to store [metadata](http://docs.amazonwebservices.com/AmazonS3/latest/index.html?UsingMetadata.html). Choose *File →
-Info (macOS `⌘I` Windows `Alt+Return`) → Metadata* to edit headers.
+You can edit standard HTTP headers and add [custom HTTP headers](../../cyberduck/info.md#metadata-http-headers) to files to store [metadata](http://docs.amazonwebservices.com/AmazonS3/latest/index.html?UsingMetadata.html). Choose *File → Info (macOS `⌘I` Windows `Alt+Return`) → Metadata* to edit headers.
 
 ### Default Metadata
 
-Currently only possible using
-a [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) you can define default
-headers to be added for uploads. Multiple headers must be separated using a whitespace delimiter. Key and value of a
-header are separated with `=`. For example, if you want to add an HTTP header for Cache-Control and one named `Creator`
-you would set
+Currently only possible using a [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) you can define default headers to be added for uploads. Multiple headers must be separated using a whitespace delimiter. Key and value of a header are separated with `=`. For example, if you want to add an HTTP header for Cache-Control and one named `Creator` you would set
 
-	s3.metadata.default="Cache-Control=public,max-age=86400 Creator=Cyberduck"
+```
+s3.metadata.default="Cache-Control=public,max-age=86400 Creator=Cyberduck"
+```
 
 ### Cache Control Setting
 
-This option lets you control how long a client accessing objects from your S3 bucket will cache the content and thus
-lowering the number of access to your S3 storage. In conjunction with Amazon CloudFront, it controls the time an object
-stays in an edge location until it expires. After the object expires, CloudFront must go back to the origin server the
-next time that edge location needs to serve that object. By default, all objects automatically expire after 24 hours
-when no custom `Cache-Control` header is set.
+This option lets you control how long a client accessing objects from your S3 bucket will cache the content and thus lowering the number of access to your S3 storage. In conjunction with Amazon CloudFront, it controls the time an object stays in an edge location until it expires. After the object expires, CloudFront must go back to the origin server the next time that edge location needs to serve that object. By default, all objects automatically expire after 24 hours when no custom `Cache-Control` header is set.
 
-The default setting is `Cache-Control: public,max-age=2052000` when choosing to add a custom `Cache-Control` header in
-the [Info](../../cyberduck/info.md) panel which translates to a cache expiration of one month (one month in seconds
-equals more or less `60*60*24*30`).
+The default setting is `Cache-Control: public,max-age=2052000` when choosing to add a custom `Cache-Control` header in the [Info](../../cyberduck/info.md) panel which translates to a cache expiration of one month (one month in seconds equals more or less `60*60*24*30`).
 
-Use the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) `s3.cache.seconds` to
-set a custom default value
+Use the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) `s3.cache.seconds` to set a custom default value
 
-	s3.cache.seconds=2052000
+```
+s3.cache.seconds=2052000
+```
 
 ### References
 
 - [Amazon CloudFront and Your Live System](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-working-with.html)
-- Read more
-  about [Amazon CloudFront Object Expiration](http://docs.amazonwebservices.com/AmazonCloudFront/latest/DeveloperGuide/index.html?Expiration.html)
+- Read more about [Amazon CloudFront Object Expiration](http://docs.amazonwebservices.com/AmazonCloudFront/latest/DeveloperGuide/index.html?Expiration.html)
 
-```{tip}
+:::{tip}
 Use `curl -I <http://<bucketname>.s3.amazonaws.com/<key>` to debug HTTP headers.
-```
+:::
 
 ## Server Side Encryption (SSE)
 
-[Server-side encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) for stored files is
-supported and can be enabled by default for all uploads in the S3 preferences or for individual files in the *File →
-Info (macOS `⌘I` Windows `Alt+Return`) → S3*. AWS handles key management and key protection for you.
+[Server-side encryption](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) for stored files is supported and can be enabled by default for all uploads in the S3 preferences or for individual files in the *File → Info (macOS `⌘I` Windows `Alt+Return`) → S3*. AWS handles key management and key protection for you.
 
 ### Defaults
 
@@ -769,13 +671,11 @@ You can override these default settings in the *File → Info (macOS `⌘I` Wind
 
 ### Server-Side Encryption with Amazon S3-Managed Keys (SSE-S3)
 
-When changing the setting for a folder or bucket you are prompted to confirm the recursive operation on all files
-contained in the selected bucket or folder.
+When changing the setting for a folder or bucket you are prompted to confirm the recursive operation on all files contained in the selected bucket or folder.
 
 ### Server-Side Encryption with AWS KMS-Managed Keys (SSE-KMS)
 
-Among the default `SSE-S3 (AES-256)`, the server-side encryption (SSE) dropdown list allows choosing from all private
-keys managed in AWS Key Management Service (KMS).
+Among the default `SSE-S3 (AES-256)`, the server-side encryption (SSE) dropdown list allows choosing from all private keys managed in AWS Key Management Service (KMS).
 
 #### Permissions
 
@@ -783,8 +683,7 @@ This requires the `kms:ListKeys` and `kms:ListAliases` permission for the AWS cr
 
 ![AWS SSE-KMS Private Key Selection](_images/AWS_SSE-KMS_Private_Key_Selection.png)
 
-When changing the setting for a folder or bucket you are prompted to confirm the recursive operation on all files
-contained in the selected bucket or folder.
+When changing the setting for a folder or bucket you are prompted to confirm the recursive operation on all files contained in the selected bucket or folder.
 
 ### Prevent Uploads of Unencrypted Files
 
@@ -794,26 +693,17 @@ Refer to the AWS Security Blog
 
 ## CloudFront CDN
 
-Amazon CloudFront delivers your static and streaming content using a global network of edge locations. Requests for your
-objects are automatically routed to the nearest edge location, so content is delivered with the best possible
-performance. Refer to [Amazon CloudFront distribution](../../protocols/cdn/cloudfront) for help about setting up
-distributions.
+Amazon CloudFront delivers your static and streaming content using a global network of edge locations. Requests for your objects are automatically routed to the nearest edge location, so content is delivered with the best possible performance. Refer to [Amazon CloudFront distribution](../../protocols/cdn/cloudfront) for help about setting up distributions.
 
 ## Website Configuration
 
-To host a static website on S3, It is possible to define an Amazon S3 bucket as a *Website Endpoint*. The configuration
-in *File → Info (macOS `⌘I` Windows `Alt+Return`) → Distribution* allows you to enable website configuration. Choose
-*Website Configuration (HTTP)* from *Delivery Method* and define an index document name that is searched for and
-returned when requests are made to the root or the subfolder of your website.
+To host a static website on S3, It is possible to define an Amazon S3 bucket as a *Website Endpoint*. The configuration in *File → Info (macOS `⌘I` Windows `Alt+Return`) → Distribution* allows you to enable website configuration. Choose *Website Configuration (HTTP)* from *Delivery Method* and define an index document name that is searched for and returned when requests are made to the root or the subfolder of your website.
 
-To access this website functionality, Amazon S3 exposes a new website endpoint for each region (US Standard, US West,
-EU, or Asia Pacific). For example, `s3-website-ap-southeast-1.amazonaws.com` is the endpoint for the Asia Pacific
-Region. The location is displayed in the *Where* field following the *Origin*.
+To access this website functionality, Amazon S3 exposes a new website endpoint for each region (US Standard, US West, EU, or Asia Pacific). For example, `s3-website-ap-southeast-1.amazonaws.com` is the endpoint for the Asia Pacific Region. The location is displayed in the *Where* field following the *Origin*.
 
 ![S3 Website Configuration](_images/S3_Website_Configuration.png)
 
-To configure Amazon CloudFront for your website endpoints, refer
-to [Website Configuration Endpoint Distributions with CloudFront CDN](../../protocols/cdn/cloudfront.md#website-configuration-endpoint-distributions-with-cloudfront-cdn).
+To configure Amazon CloudFront for your website endpoints, refer to [Website Configuration Endpoint Distributions with CloudFront CDN](../../protocols/cdn/cloudfront.md#website-configuration-endpoint-distributions-with-cloudfront-cdn).
 
 ### References
 
@@ -824,21 +714,15 @@ to [Website Configuration Endpoint Distributions with CloudFront CDN](../../prot
 
 ### Modification Date
 
-The modification date retention is only supported using the
-{download}`S3 (Timestamps) profile<https://profiles.cyberduck.io/S3%20(Timestamps).cyberduckprofile>`. When using this
-connection profile, the modification and creation dates get written into the metadata in form of `x-amz-meta-Mtime`
-and `x-amz-meta-Btime` for files uploaded to S3. .
+The modification date retention is only supported using the {download}`S3 (Timestamps) profile<https://profiles.cyberduck.io/S3%20(Timestamps).cyberduckprofile>`. When using this connection profile, the modification and creation dates get written into the metadata in form of `x-amz-meta-Mtime` and `x-amz-meta-Btime` for files uploaded to S3. .
 
-Listing folders will require an additional `HEAD` request for every file to read the modification date from the object
-metadata. This can cause performance issues due to the excessive number of requests required with large directory
-contents.
+Listing folders will require an additional `HEAD` request for every file to read the modification date from the object metadata. This can cause performance issues due to the excessive number of requests required with large directory contents.
 
-```{tip}
+:::{tip}
 Make sure to enable _Preserve modification date_ in *Preferences → Transfers → Timestamps* in Cyberduck.
-```
+:::
 
-The {download}`S3 (Timestamps) profile<https://profiles.cyberduck.io/S3%20(Timestamps).cyberduckprofile> is only
-necessary if you want to view the timestamps set in the browser.
+The {download}`S3 (Timestamps) profile<https://profiles.cyberduck.io/S3%20(Timestamps).cyberduckprofile>` is only necessary if you want to view the timestamps set in the browser.
 
 #### Interoperability
 
@@ -846,8 +730,7 @@ The timestamp metadata is interoperable with [rclone](https://rclone.org/s3/#mod
 
 ### `Listing directory / failed.` with Path in Custom S3 Endpoint
 
-When connecting to a service that requires a path prefix in all requests, you must set the `Context` property in a
-custom [connection profile](../profiles/index.md).
+When connecting to a service that requires a path prefix in all requests, you must set the `Context` property in a custom [connection profile](../profiles/index.md).
 
 ### Moved Permanently but no Location Header
 
@@ -861,24 +744,19 @@ support [multipart uploads](http://docs.aws.amazon.com/AmazonS3/latest/dev/mpuov
 ### Delete Marker
 
 When overwriting files some applications (like Windows File Explorer) will delete files prior to writing the new file.
-Thus we also forward this delete operation to S3 resulting in the delete marker being set. You can overwrite files with
-command-line tools which typically do not delete files prior to overwriting.
+Thus we also forward this delete operation to S3 resulting in the delete marker being set. You can overwrite files with command-line tools which typically do not delete files prior to overwriting.
 
 ### In Finder.app, Creating a new Top-Level Folder in S3 Fails with `Interoperability failure. Bucket name is not DNS compatible. Please contact your web hosting service provider for assistance.`
 
-A bucket name in S3 cannot have whitespace in the filename. Because a new folder created with Finder.app is
-named `Untitled Folder` the operation fails. As a workaround, create a new bucket with `mkdir` in *Terminal.app*.
+A bucket name in S3 cannot have whitespace in the filename. Because a new folder created with Finder.app is named `Untitled Folder` the operation fails. As a workaround, create a new bucket with `mkdir` in *Terminal.app*.
 
-```{note}
+:::{note}
 The bucket can be created within the Smart Synchronization mode as the folder only gets uploaded after it is renamed. Make sure to choose a filename with no whitespace. For the additional restrictions of the bucket name, refer to the [AWS bucket naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
-```
+:::
 
 ### Saving a File in TextEdit.app will Attempt to Create a Folder `/Temporary Items` on the Remote Volume. On some Servers, this may fail due to a Permission Failure or Because the Name of the Folder is not Allowed as in S3.
 
-<del>You will get the error
-message `Bucket name is not DNS compatible. Please contact your web hosting service provider for assistance.`.</del> As
-of Mountain Duck version 2.1, `.DS_Store` files are only saved in a temporary location and not stored on the mounted
-remote volume.
+<del>You will get the error message `Bucket name is not DNS compatible. Please contact your web hosting service provider for assistance.`.</del> As of Mountain Duck version 2.1, `.DS_Store` files are only saved in a temporary location and not stored on the mounted remote volume.
 
 ## References
 

--- a/protocols/s3/ionos.md
+++ b/protocols/s3/ionos.md
@@ -5,9 +5,9 @@ IONOS Cloud Object Storage
 
 ## Connection
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 ### Connection Profile
 

--- a/protocols/s3/linode.md
+++ b/protocols/s3/linode.md
@@ -7,9 +7,9 @@ Linode Object Storage
 
 ### Connection Profile
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - **Linode Object Storage (France, Paris)** {download}`Download<https://profiles.cyberduck.io/Linode%20Object%20Storage%20(fr-par-1).cyberduckprofile>` the *Linode Object Storage (Paris) Connection Profile* for preconfigured settings.
 - **Linode Object Storage (Milan, Italy)** {download}`Download<https://profiles.cyberduck.io/Linode%20Object%20Storage%20(it-mil-1).cyberduckprofile>` the *Linode Object Storage (Milan) Connection Profile* for preconfigured settings.
@@ -45,10 +45,10 @@ Within the *Create an Access Key* menu:
 
 After submitting a window will be displayed containing the *Access Key* and *Secret Key*. 
 
-```{note}
+:::{note}
 The window will only be displayed once and the *Secret Key* cannot be retrieved once the window is closed!
 Make sure to keep the credential somewhere safe.
-```
+:::
 
 ## References
 

--- a/protocols/s3/minio.md
+++ b/protocols/s3/minio.md
@@ -1,10 +1,10 @@
 MinIO Cloud Storage
 ====
 
-```{image} _images/MINIO_wordmark.png
+:::{image} _images/MINIO_wordmark.png
 :alt: MinIO Logo
 :height: 128px
-```
+:::
 
 > [MinIO](https://min.io/) is an object storage server built for cloud application developers and DevOps.</br>Store photos, videos, VMs, containers, log files, or any blob of data as objects.
 

--- a/protocols/s3/minio.md
+++ b/protocols/s3/minio.md
@@ -14,4 +14,4 @@ Download and install the [generic S3 profile](index.md#generic-s3-profiles).
 
 ### Virtual Host Style Requests
 
-Make sure to enable [virtual-host-style requests](https://github.com/minio/minio/tree/master/docs/config#domain) in your MinIO configuration. Alternatively, refer to [Disable use of Virtual Host Style Requests](index.md#disable-use-of-virtual-host-style-requests).
+Make sure to enable [virtual-host-style requests](https://github.com/minio/minio/tree/master/docs/config#domain) in your MinIO configuration. Alternatively, refer to [Connecting using Deprecated Path Style Requests](index.md#connecting-using-deprecated-path-style-requests).

--- a/protocols/s3/oraclecloud.md
+++ b/protocols/s3/oraclecloud.md
@@ -1,10 +1,10 @@
 Oracle Cloud Infrastructure
 ====
 
-```{image} _images/OCI_Object_Storage.png
+:::{image} _images/OCI_Object_Storage.png
 :alt: Oracle Drive Icon
 :width: 128px
-```
+:::
 
 > [Oracle Cloud Infrastructure (OCI)](https://oracle.com/cloud) provides two separate Object Storage solutions: *OCI Object Storage* and *OCI Object Storage Classic*. Both of them can be accessed using Cyberduck.
 
@@ -14,9 +14,9 @@ Oracle Cloud Infrastructure
 
 ### Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 For connecting to OCI Object Storage, Cyberduck version 6.4.0 or later is required. You need to use the [OCI Amazon S3 Compatible API](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/s3compatibleapi.htm).
 
@@ -41,9 +41,9 @@ Follow these instructions:
     - {download}`OCI Object Storage (uk-london-1).cyberduckprofile<https://profiles.cyberduck.io/OCI%20Object%20Storage%20(uk-london-1).cyberduckprofile>`
     - {download}`OCI Object Storage (us-ashburn-1).cyberduckprofile<https://profiles.cyberduck.io/OCI%20Object%20Storage%20(us-ashburn-1).cyberduckprofile>`
 3. Create a new bookmark and select the connection profile installed as the protocol.
-4Update the *Server* field and replace `<namespace>` with your tenancy's namespace (For more information about namespaces, and ways to find your namespace refer to the [Oracle Cloud Documentation](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/understandingnamespaces.htm))
-4. Enter the *Access Key* that you obtained while creating *Amazon S3 Compatible API Key*
-5. Enter the *Secret Key* that you obtained while creating *Amazon S3 Compatible API Key*
+4. Update the *Server* field and replace `<namespace>` with your tenancy's namespace (For more information about namespaces, and ways to find your namespace refer to the [Oracle Cloud Documentation](https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/understandingnamespaces.htm))
+5. Enter the *Access Key* that you obtained while creating *Amazon S3 Compatible API Key*
+6. Enter the *Secret Key* that you obtained while creating *Amazon S3 Compatible API Key*
 
 ## OCI Object Storage Classic
 

--- a/protocols/s3/polycloud.md
+++ b/protocols/s3/polycloud.md
@@ -19,9 +19,9 @@ Double-click on the downloaded file to activate the connection profile. Enter th
 3. Select *Generate* to confirm that you want to generate an access key.
 4. A window will show up containing the key information (Access Key ID, Secret Access Key)
 
-```{note}
+:::{note}
 The key information will only be shown once and can't be recovered. If you do lose them you can generate new keys, but you will then need to update all of your 3rd party applications with the new credentials.
-```
+:::
 
 ## References
 

--- a/protocols/s3/scaleway.md
+++ b/protocols/s3/scaleway.md
@@ -5,9 +5,9 @@ Scaleway Object Storage
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - **NL-AMS** {download}`Download<https://profiles.cyberduck.io/Scaleway%20(NL-AMS).cyberduckprofile>` the *Scaleway Object Storage (NL-AMS) Connection Profile* for preconfigured settings.
 - **FR-PAR** {download}`Download<https://profiles.cyberduck.io/Scaleway%20(FR-PAR).cyberduckprofile>` the *Scaleway Object Storage (NL-AMS) Connection Profile* for preconfigured settings.

--- a/protocols/s3/seagate.md
+++ b/protocols/s3/seagate.md
@@ -10,12 +10,12 @@ Seagate Lyve Cloud
 - Access Key ID: `<your access key>`
 - Secret Access Key: `<your secret access key>`
 
-```{hint}
+:::{hint}
 Available [endpoints](https://help.lyvecloud.seagate.com/en/s3-api-endpoint.html) are
 - US-East-1 (Virginia): `https://s3.us-east-1.lyvecloud.seagate.com`
 - US-West-1 (California): `https://s3.us-west-1.lyvecloud.seagate.com`
 - AP-Southeast-1 (Singapore): `https://s3.ap-southeast-1.lyvecloud.seagate.com`
-```
+:::
 
 ### Create Access Keys
 
@@ -26,9 +26,9 @@ You have to create service accounts within the *Lyve Cloud console* to use third
 3. Enter the name and permissions.
 4. Choose *Create*. The access key will be generated and the details of the key will be displayed in a popup window.
 
-```{note}
+:::{note}
 The prompt containing the access key information will only be displayed once. Make sure to save the details for future use.
-```
+:::
 
 ## References
 

--- a/protocols/s3/spectra.md
+++ b/protocols/s3/spectra.md
@@ -1,18 +1,18 @@
 Spectra BlackPearl Deep Storage Gateway
 ====
 
-```{image} https://cdn.cyberduck.io/img/providers/spectra.png
+:::{image} https://cdn.cyberduck.io/img/providers/spectra.png
 :alt: DreamObject Cloud Storage
 :width: 128px
-```
+:::
 
 > S3 Gateway to Deep Storage. The Spectra Logic BlackPearl Converged Storage System provides an easy, cloud-like interface to on-premise storage solutions, including to disk, tape, and cloud targets for maximum protection.
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - {download}`Download<https://profiles.cyberduck.io/Spectra%20S3%20(HTTPS).cyberduckprofile>` the *Spectra S3 (HTTPS) Connection Profile* for preconfigured settings.
 - {download}`Download<https://profiles.cyberduck.io/Spectra%20S3%20(HTTP).cyberduckprofile>` the *Spectra S3 (HTTP) Connection Profile* for preconfigured settings.

--- a/protocols/s3/synology.md
+++ b/protocols/s3/synology.md
@@ -5,9 +5,9 @@ Synology C2 Object Storage
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 1. Download the desired region for the Synology C2 Object Storage Connection Profile with preconfigured settings.
 2. Connect to S3 endpoint by following the quick start guide below.
@@ -15,12 +15,9 @@ Connection profiles can be installed from *Preferences → Profiles*.
 - **C2 Object Europe**
   - {download}`eu-001 cyberduckprofile<https://profiles.cyberduck.io/Synology%20C2%20(eu-001).cyberduckprofile>`
   - {download}`eu-002 cyberduckprofile<https://profiles.cyberduck.io/Synology%20C2%20(eu-002).cyberduckprofile>`
-
 - **C2 Object North America** 
   - {download}`us-001 cyberduckprofile<https://profiles.cyberduck.io/Synology%20C2%20(us-001).cyberduckprofile>`
   - {download}`us-002 cyberduckprofile<https://profiles.cyberduck.io/Synology%20C2%20(us-002).cyberduckprofile>`
-   
-
 - **C2 Object APAC**
   - {download}`tw-001 cyberduckprofile<https://profiles.cyberduck.io/Synology%20C2%20(tw-001).cyberduckprofile>` 
 

--- a/protocols/s3/vitanium.md
+++ b/protocols/s3/vitanium.md
@@ -1,10 +1,10 @@
 Vitanium Cloud
 ===
 
-```{image} https://cdn.cyberduck.io/img/providers/vitanium.png
+:::{image} https://cdn.cyberduck.io/img/providers/vitanium.png
 :alt: Vitanium Cloud
 :width: 128px
-```
+:::
 
 ## Connecting
 

--- a/protocols/s3/wasabi.md
+++ b/protocols/s3/wasabi.md
@@ -1,10 +1,10 @@
 Wasabi Storage
 ====
 
-```{image} https://cdn.cyberduck.io/img/providers/wasabi.png
+:::{image} https://cdn.cyberduck.io/img/providers/wasabi.png
 :alt: Wasabi Storage
 :width: 128px
-```
+:::
 
 > One simple storage solution that is faster than Amazon S3 yet cheaper than Amazon Glacier. Wasabi's immutable buckets protect you against the most common causes of data loss.
 
@@ -12,9 +12,9 @@ Wasabi Storage
 
 ## Connecting
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - **Wasabi CA Central 1 (Toronto)** {download}`Download<https://profiles.cyberduck.io/Wasabi%20(ca-central-1%20).cyberduckprofile>` the *Wasabi Storage (ca-central-1) Connection Profile* for preconfigured settings.
 - **Wasabi US East 1 (N. Virginia)** {download}`Download<https://profiles.cyberduck.io/Wasabi%20(us-east-1).cyberduckprofile>` the *Wasabi Storage (us-east-1) Connection Profile* for preconfigured settings.
@@ -40,10 +40,10 @@ You are connected with a connection profile specific to a region not matching th
 
 Connecting to buckets with dots in the bucket name can cause a certificate error. 
 
-```{image} _images/Wasabi_Certificate_Error.png
+:::{image} _images/Wasabi_Certificate_Error.png
 :alt: Certificate Error
 :width: 400px
-```
+:::
 
 ## References
 

--- a/protocols/s3/z1.md
+++ b/protocols/s3/z1.md
@@ -1,10 +1,10 @@
 Z1 Storage
 ====
 
-```{image} https://cdn.cyberduck.io/img/providers/z1.png
+:::{image} https://cdn.cyberduck.io/img/providers/z1.png
 :alt: Z1 Storage
 :width: 128px
-```
+:::
 
 > Bringing affordable backups to Africa and the World.
 

--- a/protocols/sftp/index.md
+++ b/protocols/sftp/index.md
@@ -1,29 +1,29 @@
 SFTP
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 sftptogo
-```
+:::
 
-```{image} ../_images/ftp.png
+:::{image} ../_images/ftp.png
 :alt: FTP Drive Icon
 :width: 128px
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Providers
 
 Settings are specific to service providers. Use the provided [connection profiles](../index.md#connection-profiles).
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - [SFTP To Go](sftptogo.md)
 
@@ -53,34 +53,41 @@ The following configuration options from `~/.ssh/config` are supported for SFTP 
 
 Example `~/.ssh/config` configuration:
 
-	Host myhostname
-		User myusername
-		IdentityFile ~/.ssh/mykey-rsa
+```
+Host myhostname
+	User myusername
+	IdentityFile ~/.ssh/mykey-rsa
+```
 
 To use the same key for all hosts add a wildcard entry such as
 
-	Host *
-		IdentityFile ~/.ssh/mykey-rsa
+```
+Host *
+	IdentityFile ~/.ssh/mykey-rsa
+```
 
 which is then used when configuring a new bookmark.
 
-```{important}
+:::{important}
 If you have a configuration in your `~/.ssh/config` make sure to specify the `Host` alias as hostname in your bookmark configuration. This is important for cases the `Host` alias is different from the `HostName`:
-	
-	Host myhostalias
-		HostName myverylonghostname.example.com
-		User myusername
-		IdentityFile ~/.ssh/mykey-rsa.pub
-		
-For the configuration above the hostname to specify in your bookmark is `myhostalias`.
-	
+
 ```
+Host myhostalias
+	HostName myverylonghostname.example.com
+	User myusername
+	IdentityFile ~/.ssh/mykey-rsa.pub
+```
+
+For the configuration above the hostname to specify in your bookmark is `myhostalias`.
+:::
 
 #### Default Public Key Authentication Keys
 
 You can enable the use of a default set of keys `~/.ssh/id_rsa` and `~/.ssh/id_dsa` (in this order) by setting the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) `ssh.authentication.publickey.default.enable` to `true`.
 
-	defaults write ch.sudo.cyberduck ssh.authentication.publickey.default.enable true
+```
+defaults write ch.sudo.cyberduck ssh.authentication.publickey.default.enable true
+```
 
 ### Public Key Authentication
 
@@ -101,55 +108,60 @@ OpenSSH private keys of type `rsa`, `dsa`, `ecdsa` and `ed25519` (in OpenSSL `PE
 #### Configure Public Key Authentication
 
 1. Run the command `ssh-keygen` from the Terminal.app (macOS) or console (Windows) to generate a public/private pair of keys. They will be put in your directory `~/.ssh`, though you will probably be asked to approve or change this location. When you generate the keys you will be asked for a 'passphrase'. If you use a *passphrase* then you will have to enter it each time you use the keys for authentication. That is, you will have to type in the passphrase every time you log in, just as you would with a password. If you don't enter a passphrase (just press the return key) then you will be allowed to log in without having to enter a passphrase. This can be more convenient, but it is less secure.
-	```
-	ssh-keygen -m PEM -t rsa
-	```
+```
+ssh-keygen -m PEM -t rsa
+```
 2. Copy the public key to the remote host you wish to access and add it to the file `authorized_keys` in your `~/.ssh` directory. (If that file does not exist then you should create it.) Anybody listed in the authorized_keys file (via their public key) is allowed to log-in, provided that they can prove that they possess the corresponding private key. Thus, if you have the private key in your .ssh directory on your home machine you'll be allowed in.
-	```
-	ssh hostname < ~/.ssh/id_rsa.pub 'cat >> .ssh/authorized_keys'
-	```
+```
+ssh hostname < ~/.ssh/id_rsa.pub 'cat >> .ssh/authorized_keys'
+```
 3. In the Connection Dialog or the Bookmark editor in Cyberduck select *Use Public Key Authentication* and select the private key in your `.ssh` directory.
 
 ##### OpenSSH User Certificate Authentication
 
-```{important}
+:::{important}
 * Cyberduck [8.9.0](https://cyberduck.io/changelog/) or later required
 * Mountain Duck [4.16.0](https://mountainduck.io/changelog/) or later required
-```
+:::
 
 Applies to SSH servers, which are configured with [`TrustedUserCAKeys`](https://man.openbsd.org/sshd_config#TrustedUserCAKeys), refer to your software vendor for configuration. To configure authentication with a User CA signed private key, configure the private key as described in [Configure Public Key Authentication](#configure-public-key-authentication) step 3. The signed public key file _must_ reside next to the private key file, suffixed `-cert.pub` or `.pub`. The [`CertificateFile`](https://man.openbsd.org/ssh_config#CertificateFile) configuration directive in `~/.ssh/config` is not supported. Pay attention to the server configuration and [`PubkeyAcceptedAlgorithms`](https://man.openbsd.org/sshd_config#PubkeyAcceptedAlgorithms) specifically which determines the allowed private key algorithms to authenticate with.
 
 #### Public Key Authentication Using SSH Agent
 When connecting to a SSH server, Cyberduck will lookup matching private keys from the SSH agent when attempting to authenticate with the server if no password is available and no explicit private key to use is configured in the bookmark.
 
-```{warning}
+:::{warning}
 The feature is not supported when running Cyberduck from the Mac App Store because of [sandboxing restrictions](https://github.com/iterate-ch/cyberduck/issues/13945).
-```
+:::
 
-````{tabs}
-```{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
+
 The agent `ssh-agent` is running by default on macOS. You add private key identities to the authentication agent using the program `ssh-add`. The SSH agent is located using the `IdentityAgent` directive in `~/.ssh/config` or if missing from the environment variable `SSH_AUTH_SOCK`.
-```
 
-```{group-tab} Windows
+:::
+:::{group-tab} Windows
+
 The following agents are supported:
  * [Pageant](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). Refer to [How To Use Pageant to Streamline SSH Key Authentication with PuTTY](https://www.digitalocean.com/community/tutorials/how-to-use-pageant-to-streamline-ssh-key-authentication-with-putty).
  * OpenSSH for Windows using the pipe (`\\.\pipe\openssh-ssh-agent`) by default. Use `IdentityAgent` to set a custom socket path for any other compatible agent if needed. 
-```
-````
 
-```{tip}
+:::
+::::
+
+:::{tip}
 When authenticating using Public Key Authentication with an SSH agent containing multiple identities, it makes sense to add `IdentitiesOnly yes` in `~/.ssh/config` to limit authentication attempts with this identity only. Otherwise the server may deny the connection because of too many login failures and you will receive the error _Too many authentication failures_.
-```
+:::
 
 Since the private key is not always available on the filesystem, specifying a public key as `IdentifyFile` is also supported. This can be used to authenticate using an SSH agent backed by a hardware token containing the private key for example.
 
 Example `~/.ssh/config` configuration:
 
-	Host myhostname
-		User myusername
-		IdentityFile ~/.ssh/mykey-rsa.pub
-		IdentitiesOnly yes
+```
+Host myhostname
+	User myusername
+	IdentityFile ~/.ssh/mykey-rsa.pub
+	IdentitiesOnly yes
+```
 
 ### One-Time Passcodes (2FA)
 
@@ -180,40 +192,47 @@ Upon connecting to an SSH server for the first time, you will see a message to v
 
 ### Connect via SSH Tunnel Through Bastion Server
 
-```{important}
+:::{important}
 Cyberduck [7.7](https://cyberduck.io/changelog/) or later required
-```
+:::
 
 Using the `ProxyJump` configuration directive in `~/.ssh/config` you can connect through a tunnel. The bookmark configuration refers to the target host in the internal network. We should find a `ProxyJump` directive in the OpenSSH configuration `~/.ssh/config` matching the hostname in the bookmark.
 
 Sample configuration:
 
-	Host internal
-    	HostName server.lan
-    	ProxyJump user-external@jump.example.org:2222
-    	User user-internal
+```
+Host internal
+   	HostName server.lan
+   	ProxyJump user-external@jump.example.org:2222
+   	User user-internal
+```
 
 You can also work with aliases like
 
-	Host bastion-host-nickname
-	    HostName bastion-hostname
-	    User username
-	    Port 2222
-	
-	Host remote-host-nickname
-	    HostName remote-hostname
-	    ProxyJump bastion-host-nickname
+```
+Host bastion-host-nickname
+    HostName bastion-hostname
+    User username
+    Port 2222
+```	
+
+```
+Host remote-host-nickname
+    HostName remote-hostname
+    ProxyJump bastion-host-nickname
+```
 
 ## Open in Terminal
 
 Open in *Terminal* allows you to open an SSH shell for the current working directory with a single click.
 
-```{warning}
+:::{warning}
 The feature is not supported when running Cyberduck from the Mac App Store because of [sandboxing restrictions](https://github.com/iterate-ch/cyberduck/issues/7664).
-```
+:::
 
-````{tabs}
-```{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
+
 **Terminal.app**
 
 Use *View → Customize Toolbar...* to add the *Terminal.app* toolbar icon to your browser.
@@ -223,7 +242,9 @@ Use *View → Customize Toolbar...* to add the *Terminal.app* toolbar icon to yo
 **Customize SSH Command:**<br/>
 You can change the SSH command using the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options)
 
-	defaults write ch.sudo.cyberduck terminal.command.ssh \"ssh\ -t\ {0}\ {1}@{2}\ -p\ {3}\ \\\"cd\ {4}\ \&\&\ exec\ \\\\\$SHELL\\\"\"
+```
+defaults write ch.sudo.cyberduck terminal.command.ssh \"ssh\ -t\ {0}\ {1}@{2}\ -p\ {3}\ \\\"cd\ {4}\ \&\&\ exec\ \\\\\$SHELL\\\"\"
+```
 
 where
 
@@ -244,24 +265,25 @@ No configuration change is required. Choose *iTerm2 → Make iTerm2 Default Term
 You can change a [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) to use a third-party terminal application instead of Terminal.app.
 
 - Example for iTerm2 Version 2
-	```
-	defaults write ch.sudo.cyberduck terminal.bundle.identifier com.googlecode.iterm2
-	defaults write ch.sudo.cyberduck terminal.command \"set\ t\ to\ \(make\ new\ terminal\)\\ntell\ t\\nset\ s\ to\ \(launch\ session\ \\\"Default\ Session\\\"\)\\ntell\ s\\nwrite\ text\ \\\"{0}\\\"\\nend\ tell\\nend\ tell\"
-	```
+```
+defaults write ch.sudo.cyberduck terminal.bundle.identifier com.googlecode.iterm2
+defaults write ch.sudo.cyberduck terminal.command \"set\ t\ to\ \(make\ new\ terminal\)\\ntell\ t\\nset\ s\ to\ \(launch\ session\ \\\"Default\ Session\\\"\)\\ntell\ s\\nwrite\ text\ \\\"{0}\\\"\\nend\ tell\\nend\ tell\"
+```
 - Example for iTerm2 Version 3
-	```
-	defaults write ch.sudo.cyberduck terminal.bundle.identifier com.googlecode.iterm2
-	defaults write ch.sudo.cyberduck terminal.command \"set\ t\ to\ \(create\ window\ with\ default\ profile\)\\ntell\ t\\nset\ s\ to\ \(current\ session\)\\ntell\ s\\nwrite\ text\ \\\"{0}\\\"\\nend\ tell\\nend\ tell\"
-	```
+```
+defaults write ch.sudo.cyberduck terminal.bundle.identifier com.googlecode.iterm2
+defaults write ch.sudo.cyberduck terminal.command \"set\ t\ to\ \(create\ window\ with\ default\ profile\)\\ntell\ t\\nset\ s\ to\ \(current\ session\)\\ntell\ s\\nwrite\ text\ \\\"{0}\\\"\\nend\ tell\\nend\ tell\"
+```
 
 To reset to the default settings use:
 
-	defaults delete ch.sudo.cyberduck terminal.bundle.identifier
-	defaults delete ch.sudo.cyberduck terminal.command
-
+```
+defaults delete ch.sudo.cyberduck terminal.bundle.identifier
+defaults delete ch.sudo.cyberduck terminal.command
 ```
 
-```{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 **Disable WSL**
 
@@ -279,9 +301,8 @@ Use *View → Customize Toolbar...* to add the *Open in Putty* toolbar icon to y
 **Location of the PuTTY installation:**<br/>
 By default, the executable `putty.exe` must be located in your user home folder. You can change the install location by editing the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options) `terminal.command.ssh` to point to the path of the executable.
 
-```
-
-````
+:::
+::::
 
 ## Distribution (CDN)
 
@@ -291,9 +312,9 @@ You can enable custom origin [Amazon CloudFront (Content Delivery Network) distr
 
 The remote systems must have the archiving tools `tar` or `zip` installed respectively. Use *View → Customize Toolbar...* to add the Archive toolbar button to your browser window. It is not included in the default toolbar configuration.
 
-```{note}
+:::{note}
 _Send custom commands_ and _Create and expand ZIP/TAR Archives_ are limited to FTP and SFTP. 
-```
+:::
 
 ### Archive
 
@@ -309,13 +330,14 @@ Select one or more files to expand in the current working directory.
 
 You can send any remote command to a remote SSH server. This is for example useful if you want a HTTP server to reload its configuration or changing the ownership of files using *chown* on a `UNIX` system.
 
-```{note}
+:::{note}
 The current working directory is always your use home. Determine using pwd to get the absolute path.
-```
-```{image} ../_images/command.png
+:::
+
+:::{image} ../_images/command.png
 :alt: Send Command
 :width: 600px
-```
+:::
 
 ## Preferences
 
@@ -393,42 +415,39 @@ Cyberduck refuses to connect if there are malformed entries in your `known_hosts
 
 Symbolic links are only resolved as such when the target points to a location on the mounted volume.
 
-````{tabs}
-```{group-tab} macOS
+::::{tabs}
+:::{group-tab} macOS
 
 Symlinks can only be displayed as such if the target is pointing to a location on the mounted volume. Otherwise, they are displayed as a regular file or folder.
 
-```
-```{group-tab} Windows
+:::
+:::{group-tab} Windows
 
 Symlink is displayed as a regular file or folder.
 
-```
-````
+:::
+::::
 
 #### File Permissions Reset when Saving File
 
-````{tabs}
-```{group-tab} macOS
+:::{admonition} macOS
+:class: note 
 
 Mountain Duck will forward all permission changes from Finder or any other application to the SFTP server. There is a [hidden configuration option](../../mountainduck/preferences.md#hidden-configuration-options) `fs.setattr.chmod=false` to disable the writing of permissions.
-
-```
-````
+:::
 
 #### File Owner Reset When Saving File
 
-````{tabs}
-```{group-tab} macOS
+::::{admonition} macOS
+:class: note 
 
 Some editors save files using an *Atomic Save* feature that writes changes to a file to a temporary file later replacing the edited file by renaming the temporary file to the name of the edited file. This works well on local filesystems, where there is support to retain the owner of the file that is different from the editing user using a special [function call](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man2/exchangedata.2.html). This does not work for volumes mounted with Mountain Duck and the file owner will be reset to the default owner for new files created on the server by the logged-in user. As a workaround, try to find a setting for the editor to disable the *Atomic Save* feature.
 
-```{seealso}
+:::{seealso}
 - [TextMate Atomic Saving](https://github.com/textmate/textmate/blob/master/Applications/TextMate/about/Changes.md#atomic-saving)
-```
+:::
 
-```
-````
+::::
 
 #### Free Space Calculation is Incorrect
 

--- a/protocols/sftp/index.md
+++ b/protocols/sftp/index.md
@@ -108,13 +108,13 @@ OpenSSH private keys of type `rsa`, `dsa`, `ecdsa` and `ed25519` (in OpenSSL `PE
 #### Configure Public Key Authentication
 
 1. Run the command `ssh-keygen` from the Terminal.app (macOS) or console (Windows) to generate a public/private pair of keys. They will be put in your directory `~/.ssh`, though you will probably be asked to approve or change this location. When you generate the keys you will be asked for a 'passphrase'. If you use a *passphrase* then you will have to enter it each time you use the keys for authentication. That is, you will have to type in the passphrase every time you log in, just as you would with a password. If you don't enter a passphrase (just press the return key) then you will be allowed to log in without having to enter a passphrase. This can be more convenient, but it is less secure.
-```
-ssh-keygen -m PEM -t rsa
-```
+	```
+	ssh-keygen -m PEM -t rsa
+	```
 2. Copy the public key to the remote host you wish to access and add it to the file `authorized_keys` in your `~/.ssh` directory. (If that file does not exist then you should create it.) Anybody listed in the authorized_keys file (via their public key) is allowed to log-in, provided that they can prove that they possess the corresponding private key. Thus, if you have the private key in your .ssh directory on your home machine you'll be allowed in.
-```
-ssh hostname < ~/.ssh/id_rsa.pub 'cat >> .ssh/authorized_keys'
-```
+	```
+	ssh hostname < ~/.ssh/id_rsa.pub 'cat >> .ssh/authorized_keys'
+	```
 3. In the Connection Dialog or the Bookmark editor in Cyberduck select *Use Public Key Authentication* and select the private key in your `.ssh` directory.
 
 ##### OpenSSH User Certificate Authentication

--- a/protocols/sharepoint.md
+++ b/protocols/sharepoint.md
@@ -1,14 +1,14 @@
 Microsoft SharePoint
 ====
 
-```{image} _images/onedrive.png
+:::{image} _images/onedrive.png
 :alt: Microsoft OneDrive
 :width: 128px
-```
+:::
 
-```{tip}
+:::{tip}
 Download [Mountain Duck](https://mountainduck.io/) to access in Finder on macOS & Windows Explorer.
-```
+:::
 
 ## SharePoint Online
 
@@ -27,11 +27,12 @@ Connect to *SharePoint Online* with the built-in *Microsoft SharePoint connectio
 
 In case you are trying to access a site that isn't listed when connecting with the *Microsoft SharePoint* connection profile you can try to access the missing site with help of the *Microsoft SharePoint Site* connection profile. While using the *Microsoft SharePoint Site* connection profile you are required to use your SharePoint hostname (`contoso.sharepoint.com`) and the URL prefix path configured for your SharePoint site. 
 
-```{note}
+:::{note}
 You can't mount a specific directory with this method as the Path field is used for the URL prefix path.
-```
+:::
 
 ### SharePoint Hybrid
+
 If you have your own SharePoint Server but opted in to enable *Microsoft Graph*-connectivity to your SharePoint Server, you may be able to use the built-in *Microsoft SharePoint*-Profile.
 
 Please refer to the official documentation from Microsoft for detailed setup guides.
@@ -76,8 +77,10 @@ Basic Authentication should only be used when using secured connection over TLS 
 
 If you need to set the `domain` and `workstation`, you can do so using a [hidden configuration option](../cyberduck/preferences.md#hidden-configuration-options).
 
-	defaults write ch.sudo.cyberduck webdav.ntlm.workstation MYWORKSTATION
-	defaults write ch.sudo.cyberduck webdav.ntlm.domain MYDOMAIN
+```
+defaults write ch.sudo.cyberduck webdav.ntlm.workstation MYWORKSTATION
+defaults write ch.sudo.cyberduck webdav.ntlm.domain MYDOMAIN
+```
 
 #### Configuration
 
@@ -100,6 +103,7 @@ A list of file versions can be viewed in the *Versions* tab of the *[Info](../cy
 ## Limitations
 
 ### Top Level folder
+
 It is not possible to create a top level folder in Mountain Duck or Cyberduck. Instead, the following virtual top level folders are displayed which cannot be moved or renamed:
 
 | Folder Name |
@@ -110,4 +114,5 @@ It is not possible to create a top level folder in Mountain Duck or Cyberduck. I
 | Sites       |
 
 ### Quota
+
 Quota reporting is only supported for the *Drives* folder within their respective site folder.

--- a/protocols/smb.md
+++ b/protocols/smb.md
@@ -11,7 +11,6 @@ SMB
 :local:
 ```
 
-
 > [SMB (Server Message Block)](https://en.wikipedia.org/wiki/Server_Message_Block) is used to access Windows File Shares or a Samba Linux Server.
 
 ## Connecting
@@ -29,11 +28,13 @@ To connect to a SMB server, choose _SMB (Server Message Block)_.
 ```
 
 ### Authentication
+
 Username and password must be provided for authentication using NTLM. The optional domain name defaults to `WORKGROUP` and can be customized as part of the username in the format `REALM\username` in the _Username_ input field when adding a bookmark. Depending on the server setup this can be
 - `COMPUTERNAME\username`
 - `NETBIOSDOMAINNAME\username`
 
 ### Share Name
+
 To connect to a specific share, you can configure a _Path_ in the bookmark. When omitted an attempt is made to list all available shares from the server. On failure retrieving share names from the server, a prompt is displayed to enter the share name when connecting.
 
 ```{image} _images/SMB_Share.png
@@ -53,7 +54,10 @@ SMB protocol support has been tested with connections to the following server im
 
 You can list shares with [Cyberduck CLI](https://duck.sh/) using
 
-	duck --list smb:/server/share/
+```
+duck --list smb:/server/share/
+```
 
 ## Limitations
+
 - Copying or moving files between shares is not supported

--- a/protocols/smb.md
+++ b/protocols/smb.md
@@ -1,31 +1,31 @@
 SMB
 ====
 
-```{image} _images/ftp.png
+:::{image} _images/ftp.png
 :alt: FTP Drive Icon
 :width: 128px
-```
+:::
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 > [SMB (Server Message Block)](https://en.wikipedia.org/wiki/Server_Message_Block) is used to access Windows File Shares or a Samba Linux Server.
 
 ## Connecting
 
-```{important}
+:::{important}
 * Cyberduck [8.7.0](https://cyberduck.io/changelog/) or later required
 * Mountain Duck [5.0.0](https://mountainduck.io/changelog/) or later required
-```
+:::
 
 To connect to a SMB server, choose _SMB (Server Message Block)_.
 
-```{image} _images/SMB_Connection.png
+:::{image} _images/SMB_Connection.png
 :alt: SMB Connection
 :width: 700px
-```
+:::
 
 ### Authentication
 
@@ -37,10 +37,10 @@ Username and password must be provided for authentication using NTLM. The option
 
 To connect to a specific share, you can configure a _Path_ in the bookmark. When omitted an attempt is made to list all available shares from the server. On failure retrieving share names from the server, a prompt is displayed to enter the share name when connecting.
 
-```{image} _images/SMB_Share.png
+:::{image} _images/SMB_Share.png
 :alt: SMB Share Input
 :width: 700px
-```
+:::
 
 ### Interoperability
 

--- a/protocols/webdav/index.md
+++ b/protocols/webdav/index.md
@@ -1,7 +1,7 @@
 WebDAV
 ====
 
-```{toctree}
+:::{toctree}
 :hidden:
 :titlesonly:
 bigcommerce
@@ -11,22 +11,22 @@ nextcloud
 pcloud
 seafile
 kdrive
-```
+:::
 
 You can connect to any WebDAV compliant server using both HTTP and HTTP/SSL. Mutual TLS with a client certificate for authentication is supported.
 
-```{contents} Content
+:::{contents} Content
 :depth: 2
 :local:
-```
+:::
 
 ## Providers
 
 Settings are specific to service providers. Use the provided [connection profiles](../index.md#connection-profiles).
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - [Nextcloud](nextcloud.md)
 - [ownCloud](nextcloud.md)
@@ -62,6 +62,7 @@ Choose *WebDAV (HTTP/SSL)* as the connection protocol to secure the connection u
 
 :::{admonition} TLSv1 and TLSv1.1 deprecation
 :class: warning
+
 TLSv1 and TLSv1.1 are no longer supported as of
 * Cyberduck [8.1.0](https://github.com/iterate-ch/cyberduck/milestone/184) or later
 * Mountain Duck [4.9.0](https://mountainduck.io/changelog/) or later
@@ -99,21 +100,18 @@ You can edit custom properties using File → Info → Metadata.
 
 ## Locking
 
-````{tabs}
-
-```{tab} Cyberduck
+::::{tabs}
+:::{group-tab} Cyberduck
 
 Locking is not supported [editing](../../cyberduck/edit.md) with Cyberduck.
 
-```
-
-```{tab} Mountain Duck
+:::
+:::{group-tab} Mountain Duck
 
 Mountain Duck supports locking using `LOCK` and `UNLOCK` methods when opening documents for editing. Refer to [File Locking](../../mountainduck/locking).
 
-```
-
-````
+:::
+::::
 
 ## Distribution (CDN)
 
@@ -137,13 +135,15 @@ Saving the modification dates requires support from server storing metadata in c
 
 If your server requires the use of UTF-8 character set for authentication, set the [hidden configuration option](../../cyberduck/preferences.md#hidden-configuration-options)
 
-	http.credentials.encoding=UTF-8
+```
+http.credentials.encoding=UTF-8
+```
 
 ### Too Many Folders are Displayed
 
-```{attention}
+:::{attention}
 This only applies if you access a Synology Diskstation.
-```
+:::
 
 If the file listing shows additional folders of the file tree that are usually not visible try to uncheck the checkbox *disable directory browsing* within the advanced settings for a shared folder on your Synology Diskstation.
 
@@ -153,11 +153,15 @@ The virtual host set up by the hosting provider is most possibly misconfigured. 
 
 You can verify the wrong server setup by running `openssl` with server name indication (SNI) enabled.
 
-	openssl s_client -servername <servername> -tlsextdebug -msg -connect <servername>:443
+```
+openssl s_client -servername <servername> -tlsextdebug -msg -connect <servername>:443
+```
 
 This will print
 
-	<<< TLS 1.0 Alert [length 0002], warning unrecognized_name
+```
+<<< TLS 1.0 Alert [length 0002], warning unrecognized_name
+```
 
 during the handshake, if there is a configuration problem.
 

--- a/protocols/webdav/kdrive.md
+++ b/protocols/webdav/kdrive.md
@@ -3,7 +3,7 @@ Infomaniak kDrive
 
 > kDrive is an online platform which enables you to retain a copy of your files and share them with employees.
 
-### Connecting
+## Connecting
 
 Enter the following information in the [bookmark](../../cyberduck/bookmarks.md):
 
@@ -14,12 +14,12 @@ Enter the following information in the [bookmark](../../cyberduck/bookmarks.md):
     - If two-step authentication is not activated, use the password for your Infomaniak account
     - If two-step authentication is activated, generate an [application password](https://manager.infomaniak.com/v3/profile/application-password)
 
-### Known Issues
+## Known Issues
 
-#### Can't Upload Files (Mountain Duck)
+### Can't Upload Files (Mountain Duck)
 
 kDrive doesn't accept uploads with unknown file sizes. Because of this files can't be uploaded within the *Online* mode as the actual file size can't be reported at the beginning of the upload. The *Smart Synchronization* mode can be used instead as a workaround.
 
-### References
+## References
 
 - [kDrive: logging in to your Drive via WebDAV](https://www.infomaniak.com/en/support/faq/2409/kdrive-logging-in-to-your-drive-via-webdav)

--- a/protocols/webdav/nextcloud.md
+++ b/protocols/webdav/nextcloud.md
@@ -1,47 +1,44 @@
 NextCloud & ownCloud
 ====
 
-`````{tabs}
+:::::{tabs}
+::::{group-tab} Nextcloud
 
-````{tab} Nextcloud
-
-```{image} _images/Nextcloud_Drive_icon.png
+:::{image} _images/Nextcloud_Drive_icon.png
 :alt: Nextcloud Drive Icon
 :height: 128px
-```
+:::
 
 > [Nextcloud Files](https://nextcloud.com/files/) is an on-premise, open-source file sync and share solution designed to be easy-to-use and highly secure.
 
-````
+::::
+::::{group-tab} ownCloud
 
-````{tab} ownCloud
-
-```{image} _images/ownCloud_Drive_icon.png
+:::{image} _images/ownCloud_Drive_icon.png
 :alt: ownCloud Drive Icon
 :height: 128px
-```
+:::
 
 > [ownCloud](https://owncloud.org/features/) is the most straightforward way to file sync and share data. You don’t need to worry about where or how to access your files. With ownCloud, all your data is where ever you are; accessible on all devices, any time.
 
-````
+::::
+:::::
 
-`````
-
-```{tip}
+:::{tip}
 Download [Mountain Duck](https://mountainduck.io/) as an alternative to *Desktop Client* from Nextcloud & ownCloud.
-```
+:::
 
 ## Connecting
 
 ### Connection Profiles
 
-`````{tabs}
-````{tab} Nextcloud
+:::::{tabs}
+::::{group-tab} Nextcloud
 
 Select the connection profile `Nextcloud` for _Protocol_ bundled by default.
-````
 
-````{tab} ownCloud
+::::
+::::{group-tab} ownCloud
 
 Select the connection profile `ownCloud` for _Protocol_ bundled by default. 
 
@@ -49,46 +46,46 @@ Select the connection profile `ownCloud` for _Protocol_ bundled by default.
 
 Connecting to *ownCloud Infinite Scale* the default authentication scheme is OpenID Connect. It requires the client registration in the identity provider in ownCloud via *Keycloak*. Additionally you need a custom [connection profile](https://github.com/iterate-ch/profiles/pull/83/files) to connect.
 
-```{note}
+:::{note}
 Basic Authentication is disabled by default. For additional information refer to the [ownCloud documentation](https://doc.owncloud.com/ocis/next/deployment/services/s-list/auth-basic.html).
-```
+:::
 
 **Import client configuration for Keycloak**
 
 To test without a custom deployment, use the public instance running at `ocis.ocis-keycloak.latest.owncloud.works` with the identity provider at `keycloak.ocis-keycloak.latest.owncloud.works` (username and password: `admin`).
 
 The client configuration to match the provided connection profile can be imported from the [ownCloud Github repository](https://github.com/owncloud/ocis/blob/7af9cd9e53183acbaac2ffbc6414402bdef1f5d4/deployments/examples/ocis_keycloak/config/keycloak/clients/cyberduck.json) to allow OAuth authentications from [Cyberduck](https://cyberduck.io) & [Mountain Duck](https://mountainduck.io).
-````
 
-````{tab} WebDAV
+::::
+::::{group-tab} WebDAV
 
 Alternatively you can connect using `WebDAV (HTTPS)` with the default path set to `/remote.php/webdav/`.
 
 ![Nextcloud Bookmark Window](_images/NextCloud_Bookmark_Window.png)
-````
-`````
+
+::::
+:::::
 
 
-```{tip}
+:::{tip}
 The default path `/remote.php/dav/files/<username>` will be used with no custom setting in _Path_ to access the WebDAV API.
-```
+:::
 
-```{attention}
+:::{attention}
 You are required to set a _Path_ only if your installation is accessible under a subdirectory such as `example.net/cloud/` this can be indicated by setting a default path of `directory/remote.php/webdav`. You can omit the value in _Path_ if your installation defaults to the root of your domain and is accessible at `example.net/remote.php/dav/files/<username>`. 
-```
+:::
 
 ### Obtain WebDAV Address From Server
 
 Connect to your Nextcloud or ownCloud server in your web browser and obtain the WebDAV address from _Settings_ in the lower left. Paste the copied server address into the *Server* field and finish editing. From the pasted URL the hostname is set in _Server_ and the document root of your Nextcloud or ownCloud installation in _Path_.
 
-```{warning}
+:::{warning}
 Make sure to set in _Username_ the actual username instead of the email address.
-```
+:::
 
 ### 2-Factor Authentication
 
 With 2-factor authentication enabled, you will need to create an app password instead of your regular login credentials. You should find it in *Personal → App passwords*.
-
 
 ## Features
 
@@ -112,9 +109,9 @@ Create different [shares](../../cyberduck/share.md#nextcloud--owncloud) using th
 
 Connecting to *ownCloud Infinite Scale*, interrupted uploads can be resumed at any time.
 
-```{note}
+:::{note}
 Cyberduck 8.9.0 or later is required.
-```
+:::
 
 ## Known Limitations
 

--- a/protocols/webdav/pcloud.md
+++ b/protocols/webdav/pcloud.md
@@ -5,15 +5,15 @@ pCloud
 
 ## Connecting
 
-```{attention}
+:::{attention}
 WebDAV access is only available for paid plans.
-```
+:::
 
 ### Connection Profiles
 
-```{note}
+:::{note}
 Connection profiles can be installed from *Preferences → Profiles*.
-```
+:::
 
 - **pCloud Europe (Luxemburg):** {download}`Download<https://profiles.cyberduck.io/pCloud%20Europe%20(Luxemburg).cyberduckprofile>` the *pCloud Europe (Luxemburg) Connection Profile* for preconfigured settings.
 - **pCloud Texas (USA):** {download}`Download<https://profiles.cyberduck.io/pCloud%20Texas%20(USA).cyberduckprofile>` the *pCloud Texas (USA) Connection Profile* for preconfigured settings.	
@@ -38,9 +38,9 @@ Connection profiles can be installed from *Preferences → Profiles*.
 
 Using Mountain Duck and pCloud Client simultaneously can cause issues for the pCloud Client. The Client requires an older version of the device driver than Mountain Duck and can't deal with the newer version installed by Mountain Duck. 
 
-```{note}
+:::{note}
 Reported for pCloud Client version 4.0.0 (Windows).
-```
+:::
 
 ## References
 


### PR DESCRIPTION
- replaced all ` ``` ` with `:::` apart from codeblocks
- adjusted overall format
- corrected deprecated wiki link on the minio page
- resolved header formatting errors
- replaced singular tabs with admonitions
- added formatting guideline documentation into the "Foprmatting_Cheat-Sheet.md" file