### PR TITLE
Update integrated.md

### DIFF
--- a/mountainduck/connect/integrated.md
+++ b/mountainduck/connect/integrated.md
@@ -22,6 +22,10 @@ Mountain Duck 5 required.
 You can access files in _Integrated_ connect mode without being always connected the server or cloud storage.
 :::
 
+:::{tip}
+In macOS, for applications to access the mount you will have to find the location on disk. This is by default accessible at _Macintosh HD → Users → YOURUSER → Library → CloudStorage_
+:::
+
 
 ## Status of Files
 


### PR DESCRIPTION
Extended the information for macOS users in order to find the mounts for other applications.

While using third party applications, it was not straightforward to find where exactly the integrated mount is located. After finding them, I´m updating with my findings. Using macOS Tahoe 26.1 and Mountain Duck 5.1.0 